### PR TITLE
Add javascript version to alternative implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Applications may wish to exchange pairing performance and/or G<sub>2</sub> perfo
 
 Please see `Cargo.toml` for a list of primary authors of this codebase.
 
+## Alternative implementations
+
+- [noble-bls12-381](https://github.com/paulmillr/noble-bls12-381) for node.js and browsers
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
I think we should cross-link all great impls.