### PR TITLE
Add API for computing pairings using cached information about G2 elements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,3 +76,6 @@ mod pairings;
 
 #[cfg(feature = "groups")]
 pub use pairings::{pairing, Gt, MillerLoopResult};
+
+#[cfg(feature = "pairings")]
+pub use pairings::{multi_miller_loop, G2Prepared};


### PR DESCRIPTION
This is a standard optimization already present in most pairing libraries. Closes #9.

Instead of calling

```rust
pairing(&a, &b)
```

if `b` is fixed in advance, you can precompute `b_prepared = G2Prepared::from(b)` and instead compute

```rust
multi_miller_loop(&[(&a, &b_prepared)]).final_exponentiation()
```

and also, you can use this new `multi_miller_loop` API to compute the combination of many pairings like

```rust
multi_miller_loop(&[(&a, &b_prepared), (&c, &d_prepared)]).final_exponentiation()
```

and use the separate application of `final_exponentiation()` to perform batch equation checking while amortizing away the cost of applying the final exponentiation.