### PR TITLE
Change crate features to clarify functionality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --verbose --target thumbv6m-none-eabi --no-default-features --features groups
+          args: --verbose --target thumbv6m-none-eabi --no-default-features --features groups,pairings
 
   doc-links:
     name: Nightly lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ version = "2.2.1"
 default-features = false
 
 [features]
-default = ["groups", "pairings"]
+default = ["groups", "pairings", "alloc"]
 groups = []
 pairings = ["groups"]
+alloc = []
 nightly = ["subtle/nightly"]

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ This crate provides an implementation of the BLS12-381 pairing-friendly elliptic
 ## Features
 
 * `groups` (on by default): Enables APIs for performing group arithmetic with G1, G2, and GT.
-* `pairings` (on by default): Enables APIs for performing pairings. This depends on the `alloc` crate.
-* `nightly`: Enables `subtle/nightly` which prevents compiler optimizations that could jeopardize constant time operations.
+* `pairings` (on by default): Enables some APIs for performing pairings.
+* `alloc` (on by default): Enables APIs that require an allocator; these include pairing optimizations.
+* `nightly`: Enables `subtle/nightly` which tries to prevent compiler optimizations that could jeopardize constant time operations. Requires the nightly Rust compiler.
 
 ## [Documentation](https://docs.rs/bls12_381)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 // involve various binary operators, and so this lint is triggered unnecessarily.
 #![allow(clippy::suspicious_arithmetic_impl)]
 
-#[cfg(feature = "pairings")]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(test)]
@@ -71,11 +71,11 @@ mod fp6;
 const BLS_X: u64 = 0xd201000000010000;
 const BLS_X_IS_NEGATIVE: bool = true;
 
-#[cfg(feature = "groups")]
+#[cfg(feature = "pairings")]
 mod pairings;
 
-#[cfg(feature = "groups")]
+#[cfg(feature = "pairings")]
 pub use pairings::{pairing, Gt, MillerLoopResult};
 
-#[cfg(feature = "pairings")]
+#[cfg(all(feature = "pairings", feature = "alloc"))]
 pub use pairings::{multi_miller_loop, G2Prepared};

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
-#[cfg(feature = "pairings")]
+#[cfg(all(feature = "pairings", feature = "alloc"))]
 use alloc::vec::Vec;
 
 /// Represents results of a Miller loop, one of the most expensive portions
@@ -219,7 +219,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a Gt {
 impl_binops_additive!(Gt, Gt);
 impl_binops_multiplicative!(Gt, Scalar);
 
-#[cfg(feature = "pairings")]
+#[cfg(all(feature = "pairings", feature = "alloc"))]
 #[derive(Clone, Debug)]
 /// This structure contains cached computations pertaining to a $\mathbb{G}_2$
 /// element as part of the pairing function (specifically, the Miller loop) and
@@ -235,7 +235,7 @@ pub struct G2Prepared {
     coeffs: Vec<(Fp2, Fp2, Fp2)>,
 }
 
-#[cfg(feature = "pairings")]
+#[cfg(all(feature = "pairings", feature = "alloc"))]
 impl From<G2Affine> for G2Prepared {
     fn from(q: G2Affine) -> G2Prepared {
         struct Adder {
@@ -286,7 +286,7 @@ impl From<G2Affine> for G2Prepared {
     }
 }
 
-#[cfg(feature = "pairings")]
+#[cfg(all(feature = "pairings", feature = "alloc"))]
 /// Computes $$\sum_{i=1}^n \textbf{ML}(a_i, b_i)$$ given a series of terms
 /// $$(a_1, b_1), (a_2, b_2), ..., (a_n, b_n).$$
 ///
@@ -544,7 +544,7 @@ fn test_unitary() {
     assert_eq!(q, r);
 }
 
-#[cfg(feature = "pairings")]
+#[cfg(all(feature = "pairings", feature = "alloc"))]
 #[test]
 fn test_multi_miller_loop() {
     let a1 = G1Affine::generator();

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -6,7 +6,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
-#[cfg(all(feature = "pairings", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 /// Represents results of a Miller loop, one of the most expensive portions
@@ -219,7 +219,7 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a Gt {
 impl_binops_additive!(Gt, Gt);
 impl_binops_multiplicative!(Gt, Scalar);
 
-#[cfg(all(feature = "pairings", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 #[derive(Clone, Debug)]
 /// This structure contains cached computations pertaining to a $\mathbb{G}_2$
 /// element as part of the pairing function (specifically, the Miller loop) and
@@ -235,7 +235,7 @@ pub struct G2Prepared {
     coeffs: Vec<(Fp2, Fp2, Fp2)>,
 }
 
-#[cfg(all(feature = "pairings", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 impl From<G2Affine> for G2Prepared {
     fn from(q: G2Affine) -> G2Prepared {
         struct Adder {
@@ -286,7 +286,7 @@ impl From<G2Affine> for G2Prepared {
     }
 }
 
-#[cfg(all(feature = "pairings", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 /// Computes $$\sum_{i=1}^n \textbf{ML}(a_i, b_i)$$ given a series of terms
 /// $$(a_1, b_1), (a_2, b_2), ..., (a_n, b_n).$$
 ///
@@ -544,7 +544,7 @@ fn test_unitary() {
     assert_eq!(q, r);
 }
 
-#[cfg(all(feature = "pairings", feature = "alloc"))]
+#[cfg(feature = "alloc")]
 #[test]
 fn test_multi_miller_loop() {
     let a1 = G1Affine::generator();


### PR DESCRIPTION
* `pairings` now enables pairing APIs but not stuff that require `alloc`
* `alloc` is now the feature which enables pairing APIs that require `alloc`