### PR TITLE
Basic Zeroize support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ required-features = ["groups"]
 version = "2.2.1"
 default-features = false
 
+[dependencies.zeroize]
+version = "1.1.0"
+default-features = false
+features = ["zeroize_derive"]
+optional = true
+
 [features]
 default = ["groups", "pairings", "alloc"]
 groups = []

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -6,12 +6,15 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 use crate::util::{adc, mac, sbb};
 
 // The internal representation of this type is six 64-bit unsigned
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod p, with R = 2^384.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone)]
 pub struct Fp([u64; 6]);
 

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -4,9 +4,13 @@ use crate::fp6::*;
 
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 /// This represents an element $c_0 + c_1 w$ of $\mathbb{F}_{p^12} = \mathbb{F}_{p^6} / w^2 - v$.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Fp12 {
     pub c0: Fp6,
     pub c1: Fp6,

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -4,9 +4,12 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 use crate::fp::Fp;
 
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone)]
 pub struct Fp2 {
     pub c0: Fp,

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -3,9 +3,13 @@ use crate::fp2::*;
 
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 /// This represents an element $c_0 + c_1 v + c_2 v^2$ of $\mathbb{F}_{p^6} = \mathbb{F}_{p^2} / v^3 - u - 1$.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Fp6 {
     pub c0: Fp2,
     pub c1: Fp2,

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -3,6 +3,8 @@
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 use crate::fp::Fp;
 use crate::Scalar;
@@ -389,6 +391,7 @@ impl G1Affine {
 }
 
 /// This is an element of $\mathbb{G}_1$ represented in the projective coordinate space.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone, Debug)]
 pub struct G1Projective {
     x: Fp,

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -3,6 +3,8 @@
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 use crate::fp::Fp;
 use crate::fp2::Fp2;
@@ -461,6 +463,7 @@ impl G2Affine {
 }
 
 /// This is an element of $\mathbb{G}_2$ represented in the projective coordinate space.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone, Debug)]
 pub struct G2Projective {
     pub(crate) x: Fp2,

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -6,6 +6,8 @@ use crate::{G1Affine, G2Affine, G2Projective, Scalar, BLS_X, BLS_X_IS_NEGATIVE};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -13,6 +15,7 @@ use alloc::vec::Vec;
 /// Represents results of a Miller loop, one of the most expensive portions
 /// of the pairing function. `MillerLoopResult`s cannot be compared with each
 /// other until `.final_exponentiation()` is called, which is also expensive.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone, Debug)]
 pub struct MillerLoopResult(pub(crate) Fp12);
 
@@ -174,6 +177,7 @@ impl_add_binop_specify_output!(MillerLoopResult, MillerLoopResult, MillerLoopRes
 ///
 /// Typically, $\mathbb{G}_T$ is written multiplicatively but we will write it additively to
 /// keep code and abstractions consistent.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Gt(pub(crate) Fp12);
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -6,6 +6,8 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
 
 use crate::util::{adc, mac, sbb};
 
@@ -14,6 +16,7 @@ use crate::util::{adc, mac, sbb};
 // The internal representation of this type is four 64-bit unsigned
 // integers in little-endian order. `Scalar` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod q, with R = 2^256.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Clone, Copy, Eq)]
 pub struct Scalar(pub(crate) [u64; 4]);
 


### PR DESCRIPTION
Keeping #14 open for now:
* For some types `Zeroize` can't be derived and would be difficult to implement, e.g. because they contain vectors. We should evaluate which types potentially contain secret information.
* If the `zeroize` feature is enabled, we should also use it in internal computations, and clear all temporary data that is potentially secret.

On the other hand, I'd also be happy to _remove_ `Zeroize` from the groups again, if we are confident that in practice, only the field elements will be secrets.