### PR TITLE
"Optimize" psi2 for fast cofactor multiplication.

### DIFF
--- a/src/g2.rs
+++ b/src/g2.rs
@@ -901,10 +901,10 @@ impl G2Projective {
         };
 
         G2Projective {
-            // x = frobenius^2(x)/2^((p-1)/3)
-            x: self.x.frobenius_map().frobenius_map() * psi2_coeff_x,
-            // y = -frobenius^2(y)
-            y: self.y.frobenius_map().frobenius_map().neg(),
+            // x = frobenius^2(x)/2^((p-1)/3); note that q^2 is the order of the field.
+            x: self.x * psi2_coeff_x,
+            // y = -frobenius^2(y); note that q^2 is the order of the field.
+            y: self.y.neg(),
             // z = z
             z: self.z,
         }


### PR DESCRIPTION
I'm making a little pull request just to notify you, in case you wanted to align the code with the one in the RFC, and have a `psi2` with less moving parts.

It's just that when we apply Frobenius twice in this quadratic extension, we're basically applying the identity, so we can skip computing Frobenius altogether.