### PR TITLE
Implement gate-featured serde for exported structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,12 @@ edition = "2018"
 [package.metadata.docs.rs]
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 
+[dependencies]
+serde = {version = "1.0.106", optional = true}
+
 [dev-dependencies]
 criterion = "0.2.11"
+bincode = "1.2.1"
 
 [[bench]]
 name = "groups"
@@ -25,11 +29,12 @@ version = "2.2.1"
 default-features = false
 
 [features]
-default = ["groups", "pairings", "alloc"]
+default = ["groups", "pairings", "alloc", "serial"]
 groups = []
 pairings = ["groups"]
 alloc = []
 nightly = ["subtle/nightly"]
+serial = []
 
 # GLV patents US7110538B2 and US7995752B2 expire in September 2020.
 endo = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 rustdoc-args = [ "--html-in-header", "katex-header.html" ]
 
 [dependencies]
-serde = {version = "1.0.106", optional = true}
+serde = {version = "1.0.106",features = ["derive"], optional = true}
 
 [dev-dependencies]
 criterion = "0.2.11"
@@ -29,12 +29,11 @@ version = "2.2.1"
 default-features = false
 
 [features]
-default = ["groups", "pairings", "alloc", "serial"]
+default = ["groups", "pairings", "alloc", "serde"]
 groups = []
 pairings = ["groups"]
 alloc = []
 nightly = ["subtle/nightly"]
-serial = []
 
 # GLV patents US7110538B2 and US7995752B2 expire in September 2020.
 endo = []

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -142,6 +142,62 @@ impl<'a, 'b> Mul<&'b Fp> for &'a Fp {
     }
 }
 
+#[cfg(feature = "serde")]
+use serde::{de::Visitor, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(feature = "serde")]
+impl Serialize for Fp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tup = serializer.serialize_seq(Some(48))?;
+        let fp_as_bytes = self.to_bytes();
+        for i in 0..48 {
+            tup.serialize_element(&fp_as_bytes[i])?;
+        }
+        tup.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Fp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct FpVisitor;
+
+        impl<'de> Visitor<'de> for FpVisitor {
+            type Value = Fp;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("a prover key with valid powers per points")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Fp, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut bytes = [0u8; 48];
+                for i in 0..48 {
+                    bytes[i] = seq
+                        .next_element()?
+                        .ok_or(serde::de::Error::invalid_length(i, &"expected 48 bytes"))?;
+                }
+                let res = Fp::from_bytes(&bytes);
+                if res.is_some().unwrap_u8() == 1u8 {
+                    return Ok(res.unwrap());
+                } else {
+                    return Err(serde::de::Error::custom(&"fp was not canonically encoded"));
+                }
+            }
+        }
+
+        deserializer.deserialize_seq(FpVisitor)
+    }
+}
+
 impl_binops_additive!(Fp, Fp);
 impl_binops_multiplicative!(Fp, Fp);
 
@@ -856,4 +912,15 @@ fn test_lexicographic_largest() {
         ])
         .lexicographically_largest()
     ));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn fp_serde_roundtrip() {
+    use bincode;
+    let fp = Fp::one();
+    let ser = bincode::serialize(&fp).unwrap();
+    let deser: Fp = bincode::deserialize(&ser).unwrap();
+
+    assert_eq!(fp, deser);
 }

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -962,7 +962,7 @@ fn test_lexicographic_largest() {
 fn fp2_serde_roundtrip() {
     use bincode;
 
-    let fp2 = Fp2{
+    let fp2 = Fp2 {
         c0: Fp::one(),
         c1: Fp::one(),
     };

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -48,6 +48,96 @@ impl PartialEq for Fp2 {
     }
 }
 
+#[cfg(feature = "serde")]
+use serde::{
+    self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[cfg(feature = "serde")]
+impl Serialize for Fp2 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut fp2 = serializer.serialize_struct("struct Fp2", 2)?;
+        fp2.serialize_field("c0", &self.c0)?;
+        fp2.serialize_field("c1", &self.c1)?;
+        fp2.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Fp2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            C0,
+            C1,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct Fp2")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "c0" => Ok(Field::C0),
+                            "c1" => Ok(Field::C1),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct Fp2Visitor;
+
+        impl<'de> Visitor<'de> for Fp2Visitor {
+            type Value = Fp2;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct Fp2")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Fp2, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let c0 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let c1 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(Fp2 { c0, c1 })
+            }
+        }
+
+        const FIELDS: &[&str] = &["c0", "c1"];
+        deserializer.deserialize_struct("Fp2", FIELDS, Fp2Visitor)
+    }
+}
+
 impl ConditionallySelectable for Fp2 {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         Fp2 {
@@ -865,4 +955,20 @@ fn test_lexicographic_largest() {
         }
         .lexicographically_largest()
     ));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn fp2_serde_roundtrip() {
+    use bincode;
+
+    let fp2 = Fp2{
+        c0: Fp::one(),
+        c1: Fp::one(),
+    };
+
+    let ser = bincode::serialize(&fp2).unwrap();
+    let deser: Fp2 = bincode::deserialize(&ser).unwrap();
+
+    assert_eq!(fp2, deser);
 }

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -58,6 +58,102 @@ impl fmt::Debug for Fp6 {
     }
 }
 
+#[cfg(feature = "serde")]
+use serde::{
+    self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[cfg(feature = "serde")]
+impl Serialize for Fp6 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut fp2 = serializer.serialize_struct("struct Fp6", 3)?;
+        fp2.serialize_field("c0", &self.c0)?;
+        fp2.serialize_field("c1", &self.c1)?;
+        fp2.serialize_field("c2", &self.c2)?;
+        fp2.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Fp6 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            C0,
+            C1,
+            C2,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct Fp6")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "c0" => Ok(Field::C0),
+                            "c1" => Ok(Field::C1),
+                            "c2" => Ok(Field::C2),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct Fp6Visitor;
+
+        impl<'de> Visitor<'de> for Fp6Visitor {
+            type Value = Fp6;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct Fp6")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Fp6, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let c0 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let c1 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let c2 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                Ok(Fp6 { c0, c1, c2 })
+            }
+        }
+
+        const FIELDS: &[&str] = &["c0", "c1", "c2"];
+        deserializer.deserialize_struct("Fp6", FIELDS, Fp6Visitor)
+    }
+}
+
 impl ConditionallySelectable for Fp6 {
     #[inline(always)]
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
@@ -504,4 +600,21 @@ fn test_arithmetic() {
         (&a * &b).invert().unwrap()
     );
     assert_eq!(&a.invert().unwrap() * &a, Fp6::one());
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn fp6_serde_roundtrip() {
+    use bincode;
+
+    let fp6 = Fp6 {
+        c0: Fp2::one(),
+        c1: Fp2::one(),
+        c2: Fp2::one(),
+    };
+
+    let ser = bincode::serialize(&fp6).unwrap();
+    let deser: Fp6 = bincode::deserialize(&ser).unwrap();
+
+    assert_eq!(fp6, deser);
 }

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -86,12 +86,13 @@ impl PartialEq for G2Affine {
 }
 
 #[cfg(feature = "serde")]
-use serde::{Serialize, Serializer, Deserialize, Deserializer, de::Visitor};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "serde")]
 impl Serialize for G2Affine {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         use serde::ser::SerializeTuple;
         let mut tup = serializer.serialize_tuple(96)?;
@@ -105,7 +106,8 @@ impl Serialize for G2Affine {
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for G2Affine {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         struct G2AffineVisitor;
 
@@ -117,18 +119,23 @@ impl<'de> Deserialize<'de> for G2Affine {
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<G2Affine, A::Error>
-                where A: serde::de::SeqAccess<'de>
+            where
+                A: serde::de::SeqAccess<'de>,
             {
                 let mut bytes = [0u8; 96];
                 for i in 0..96 {
-                    bytes[i] = seq.next_element()?
+                    bytes[i] = seq
+                        .next_element()?
                         .ok_or(serde::de::Error::invalid_length(i, &"expected 48 bytes"))?;
                 }
                 let res = G2Affine::from_compressed(&bytes);
-                if res.is_some().unwrap_u8() == 1u8 {return Ok(res.unwrap())}
-                else {return Err(serde::de::Error::custom(
-                    &"compressed G2Affine was not canonically encoded"
-                ))}
+                if res.is_some().unwrap_u8() == 1u8 {
+                    return Ok(res.unwrap());
+                } else {
+                    return Err(serde::de::Error::custom(
+                        &"compressed G2Affine was not canonically encoded",
+                    ));
+                }
             }
         }
 

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -85,6 +85,57 @@ impl PartialEq for G2Affine {
     }
 }
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Serializer, Deserialize, Deserializer, de::Visitor};
+
+#[cfg(feature = "serde")]
+impl Serialize for G2Affine {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        use serde::ser::SerializeTuple;
+        let mut tup = serializer.serialize_tuple(96)?;
+        for byte in self.to_compressed().iter() {
+            tup.serialize_element(byte)?;
+        }
+        tup.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for G2Affine {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        struct G2AffineVisitor;
+
+        impl<'de> Visitor<'de> for G2AffineVisitor {
+            type Value = G2Affine;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("a 48-byte cannonical compressed G2Affine point from Bls12_381")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<G2Affine, A::Error>
+                where A: serde::de::SeqAccess<'de>
+            {
+                let mut bytes = [0u8; 96];
+                for i in 0..96 {
+                    bytes[i] = seq.next_element()?
+                        .ok_or(serde::de::Error::invalid_length(i, &"expected 48 bytes"))?;
+                }
+                let res = G2Affine::from_compressed(&bytes);
+                if res.is_some().unwrap_u8() == 1u8 {return Ok(res.unwrap())}
+                else {return Err(serde::de::Error::custom(
+                    &"compressed G2Affine was not canonically encoded"
+                ))}
+            }
+        }
+
+        deserializer.deserialize_tuple(96, G2AffineVisitor)
+    }
+}
+
 impl<'a> Neg for &'a G2Affine {
     type Output = G2Affine;
 
@@ -1911,4 +1962,16 @@ fn test_batch_normalize() {
             }
         }
     }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn g2_affine_serde_roundtrip() {
+    use bincode;
+
+    let gen = G2Affine::generator();
+    let ser = bincode::serialize(&gen).unwrap();
+    let deser: G2Affine = bincode::deserialize(&ser).unwrap();
+
+    assert_eq!(gen, deser);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,10 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(all(test, feature = "serial"))]
+extern crate bincode;
+
+
 #[cfg(test)]
 #[macro_use]
 extern crate std;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ extern crate alloc;
 
 #[cfg(all(test, feature = "serial"))]
 extern crate bincode;
-
+#[cfg(feature = "serde")]
+extern crate serde;
 
 #[cfg(test)]
 #[macro_use]

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -305,7 +305,7 @@ impl Serialize for G2Prepared {
         let mut g2_prepared = serializer.serialize_struct("struct G2Prepared", 2)?;
         // We encode the choice as an u8 field.
         g2_prepared.serialize_field("choice", &self.infinity.unwrap_u8())?;
-        // Since we have serde support for `Fp2` we can treat the `Vec` as a 
+        // Since we have serde support for `Fp2` we can treat the `Vec` as a
         // regular field.
         g2_prepared.serialize_field("coeffs", &self.coeffs)?;
         g2_prepared.end()
@@ -376,7 +376,10 @@ impl<'de> Deserialize<'de> for G2Prepared {
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
                 let choice: Choice = Choice::from(choice_as_u8);
-                Ok(G2Prepared { infinity: choice, coeffs })
+                Ok(G2Prepared {
+                    infinity: choice,
+                    coeffs,
+                })
             }
         }
 

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -291,6 +291,100 @@ pub struct G2Prepared {
     coeffs: Vec<(Fp2, Fp2, Fp2)>,
 }
 
+#[cfg(feature = "serde")]
+use serde::{
+    self, de::Visitor, ser::SerializeStruct, Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[cfg(feature = "serde")]
+impl Serialize for G2Prepared {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut g2_prepared = serializer.serialize_struct("struct G2Prepared", 2)?;
+        // We encode the choice as an u8 field.
+        g2_prepared.serialize_field("choice", &self.infinity.unwrap_u8())?;
+        // Since we have serde support for `Fp2` we can treat the `Vec` as a 
+        // regular field.
+        g2_prepared.serialize_field("coeffs", &self.coeffs)?;
+        g2_prepared.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for G2Prepared {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        enum Field {
+            Choice,
+            Coeffs,
+        };
+
+        impl<'de> Deserialize<'de> for Field {
+            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct FieldVisitor;
+
+                impl<'de> Visitor<'de> for FieldVisitor {
+                    type Value = Field;
+
+                    fn expecting(
+                        &self,
+                        formatter: &mut ::core::fmt::Formatter,
+                    ) -> ::core::fmt::Result {
+                        formatter.write_str("struct G2Prepared")
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "choice" => Ok(Field::Choice),
+                            "coeffs" => Ok(Field::Coeffs),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)
+            }
+        }
+
+        struct G2PreparedVisitor;
+
+        impl<'de> Visitor<'de> for G2PreparedVisitor {
+            type Value = G2Prepared;
+
+            fn expecting(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                formatter.write_str("struct G2Prepared")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<G2Prepared, V::Error>
+            where
+                V: serde::de::SeqAccess<'de>,
+            {
+                let choice_as_u8: u8 = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let coeffs = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let choice: Choice = Choice::from(choice_as_u8);
+                Ok(G2Prepared { infinity: choice, coeffs })
+            }
+        }
+
+        const FIELDS: &[&str] = &["choice", "coeffs"];
+        deserializer.deserialize_struct("G2Prepared", FIELDS, G2PreparedVisitor)
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl From<G2Affine> for G2Prepared {
     fn from(q: G2Affine) -> G2Prepared {
@@ -651,4 +745,17 @@ fn test_multi_miller_loop() {
     .final_exponentiation();
 
     assert_eq!(expected, test);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn g2_prepared_serde_roundtrip() {
+    use bincode;
+
+    let g2_prepared = G2Prepared::from(G2Affine::generator());
+    let ser = bincode::serialize(&g2_prepared).unwrap();
+    let deser: G2Prepared = bincode::deserialize(&ser).unwrap();
+
+    assert_eq!(g2_prepared.coeffs, deser.coeffs);
+    assert_eq!(g2_prepared.infinity.unwrap_u8(), deser.infinity.unwrap_u8())
 }


### PR DESCRIPTION
A few weeks ago, I needed `serde` implementations for the types that this library exports, so I coded them on our fork: https://github.com/dusk-network/bls12_381

Then I saw the suggestion raised in #35 by @hdevalence and thought that it would be nice to convert our impl to a `feature-gated behind a serde feature`.

So I modified our impl according to the gate-feature suggestion and made the PR.

Adds serde impl for:
- `G1Affine`
- `G2Affine`
- `G2Prepared` which then required `Fp`, `Fp2` & `Fp6` serde impls.

All the implementations will make the deserialization fail if any of the items is not `canonically-encoded`.

Appart from that, I think that implement `Write` and `Read` for these types would be also nice, since sometimes, you just want to move the point structures as bytes but without doing any compresions/decompressions, having them "serialized" as bytes (which would be much more performant). See: https://github.com/dusk-network/plonk/issues/190 where a `Proof` takes a considerable amount of time to be deserialized just because we call `decompression` for each point we store on it computing the security checks.

I added the `serde` feature to the `default` features group, but feel free to remove it from there since Idk if everyone will want the feature enabled by default.