### PR TITLE
Expose the MODULUS const

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -63,7 +63,7 @@ impl ConditionallySelectable for Scalar {
 
 /// Constant representing the modulus
 /// q = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
-const MODULUS: Scalar = Scalar([
+pub const MODULUS: Scalar = Scalar([
     0xffffffff00000001,
     0x53bda402fffe5bfe,
     0x3339d80809a1d805,


### PR DESCRIPTION
Hi, we're using this lib for something at @nucypher and it'd be nice to have the modulus of the `Scalar` exposed. It's presently private, and this PR makes it `pub`.

Thanks! :)