### PR TITLE
Enable the endo feature flag by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,12 @@ version = "2.2.1"
 default-features = false
 
 [features]
-default = ["groups", "pairings", "alloc"]
+default = ["groups", "pairings", "alloc", "endo"]
 groups = ["group"]
 pairings = ["groups", "pairing"]
 alloc = ["group/alloc"]
 nightly = ["subtle/nightly"]
 
-# GLV patents US7110538B2 and US7995752B2 expire in September 2020.
+# Deprecated.
+# GLV patents US7110538B2 and US7995752B2 expired in September 2020.
 endo = []

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This crate provides an implementation of the BLS12-381 pairing-friendly elliptic
 * `pairings` (on by default): Enables some APIs for performing pairings.
 * `alloc` (on by default): Enables APIs that require an allocator; these include pairing optimizations.
 * `nightly`: Enables `subtle/nightly` which tries to prevent compiler optimizations that could jeopardize constant time operations. Requires the nightly Rust compiler.
-* `endo`: Enables optimizations that leverage curve endomorphisms, which may run foul of patents US7110538B2 and US7995752B2 set to expire in September 2020.
+* `endo` (on by default): Enables optimizations that leverage curve endomorphisms. Deprecated, will be removed in a future release.
 
 ## [Documentation](https://docs.rs/bls12_381)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Changed
+- The `endo` feature is on by default. The `endo` feature flag itself is deprecated, and
+  will be removed in a future minor release.
+
 # 0.3.1
 
 # Fixed

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -917,8 +917,7 @@ impl G2Projective {
     /// parameter of BLS12-381.
     ///
     /// The endomorphism is only actually used if the crate feature `endo` is
-    /// enabled, and it is disabled by default to mitigate potential patent
-    /// issues.
+    /// enabled, which it is by default.
     pub fn clear_cofactor(&self) -> G2Projective {
         #[cfg(feature = "endo")]
         fn clear_cofactor(this: &G2Projective) -> G2Projective {


### PR DESCRIPTION
The relevant patents have now expired:

- US7110538B2 expired 2020-09-25.
- US7995752B2 expired 2020-09-15.

The feature flag is now deprecated, and will be removed in a future minor release.