### PR TITLE
Bump bitvec to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 required-features = ["groups"]
 
 [dependencies.bitvec]
-version = "0.18"
+version = "0.20"
 default-features = false
 
 [dependencies.ff]


### PR DESCRIPTION
Depends on https://github.com/zkcrypto/ff/pull/50 and probably on a bump of `ff` itself.