### PR TITLE
Basic serde support for Scalar, G1 and G2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,15 @@ default-features = false
 version = "2.2.1"
 default-features = false
 
+[dependencies.serde]
+version = "1.0"
+features = ["derive"]
+optional = true
+default-features = false
+
+[dev-dependencies.serde_test]
+version = "1.0"
+
 [features]
 default = ["groups", "pairings", "alloc", "endo"]
 groups = ["group"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ default-features = false
 
 [dependencies.serde]
 version = "1.0"
-features = ["derive"]
 optional = true
 default-features = false
 

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -1012,6 +1012,83 @@ impl UncompressedEncoding for G1Affine {
     }
 }
 
+#[cfg(feature = "serde")]
+use serde::de::Visitor;
+#[cfg(feature = "serde")]
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+impl Serialize for G1Affine {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeTuple;
+        let mut tup = serializer.serialize_tuple(48)?;
+        for byte in self.to_compressed().iter() {
+            tup.serialize_element(byte)?;
+        }
+        tup.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for G1Affine {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct G1AffineVisitor;
+
+        impl<'de> Visitor<'de> for G1AffineVisitor {
+            type Value = G1Affine;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a 48-byte compressed canonical bls12_381 G1 point")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<G1Affine, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut bytes = [0u8; 48];
+                for i in 0..48 {
+                    bytes[i] = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 48 bytes"))?;
+                }
+
+                let res = G1Affine::from_compressed(&bytes);
+                if res.is_some().into() {
+                    Ok(res.unwrap())
+                } else {
+                    Err(serde::de::Error::custom(
+                        &"G1 point was not canonically encoded",
+                    ))
+                }
+            }
+        }
+
+        deserializer.deserialize_tuple(48, G1AffineVisitor)
+    }
+}
+
+impl Serialize for G1Projective {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        G1Affine::from(*self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for G1Projective {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        G1Affine::deserialize(deserializer).map(G1Projective::from)
+    }
+}
+
 #[test]
 fn test_is_on_curve() {
     assert!(bool::from(G1Affine::identity().is_on_curve()));
@@ -1629,4 +1706,36 @@ fn test_batch_normalize() {
             }
         }
     }
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_affine_serde_serialization() {
+    use serde_test::{assert_tokens, Token};
+
+    let g = G1Affine::generator();
+    let raw_bytes = g.to_compressed();
+
+    let expected_tokens = std::iter::once(Token::Tuple { len: 48 })
+        .chain(raw_bytes.iter().map(|&b| Token::U8(b)))
+        .chain(std::iter::once(Token::TupleEnd))
+        .collect::<alloc::vec::Vec<_>>();
+
+    assert_tokens(&g, &expected_tokens);
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_projective_serde_serialization() {
+    use serde_test::{assert_tokens, Token};
+
+    let g = G1Projective::generator();
+    let raw_bytes = G1Affine::from(g).to_compressed();
+
+    let expected_tokens = std::iter::once(Token::Tuple { len: 48 })
+        .chain(raw_bytes.iter().map(|&b| Token::U8(b)))
+        .chain(std::iter::once(Token::TupleEnd))
+        .collect::<alloc::vec::Vec<_>>();
+
+    assert_tokens(&g, &expected_tokens);
 }

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -1199,6 +1199,83 @@ impl UncompressedEncoding for G2Affine {
     }
 }
 
+#[cfg(feature = "serde")]
+use serde::de::Visitor;
+#[cfg(feature = "serde")]
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+
+impl Serialize for G2Affine {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeTuple;
+        let mut tup = serializer.serialize_tuple(96)?;
+        for byte in self.to_compressed().iter() {
+            tup.serialize_element(byte)?;
+        }
+        tup.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for G2Affine {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct G2AffineVisitor;
+
+        impl<'de> Visitor<'de> for G2AffineVisitor {
+            type Value = G2Affine;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a 96-byte compressed canonical bls12_381 G2 point")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<G2Affine, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut bytes = [0u8; 96];
+                for i in 0..96 {
+                    bytes[i] = seq
+                        .next_element()?
+                        .ok_or_else(|| serde::de::Error::invalid_length(i, &"expected 96 bytes"))?;
+                }
+
+                let res = G2Affine::from_compressed(&bytes);
+                if res.is_some().into() {
+                    Ok(res.unwrap())
+                } else {
+                    Err(serde::de::Error::custom(
+                        &"G2 point was not canonically encoded",
+                    ))
+                }
+            }
+        }
+
+        deserializer.deserialize_tuple(96, G2AffineVisitor)
+    }
+}
+
+impl Serialize for G2Projective {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        G2Affine::from(*self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for G2Projective {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        G2Affine::deserialize(deserializer).map(G2Projective::from)
+    }
+}
+
 #[test]
 fn test_is_on_curve() {
     assert!(bool::from(G2Affine::identity().is_on_curve()));
@@ -2093,4 +2170,36 @@ fn test_batch_normalize() {
             }
         }
     }
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_affine_serde_serialization() {
+    use serde_test::{assert_tokens, Token};
+
+    let g = G2Affine::generator();
+    let raw_compressed_bytes = g.to_compressed();
+
+    let expected_tokens = std::iter::once(Token::Tuple { len: 96 })
+        .chain(raw_compressed_bytes.iter().map(|&b| Token::U8(b)))
+        .chain(std::iter::once(Token::TupleEnd))
+        .collect::<alloc::vec::Vec<_>>();
+
+    assert_tokens(&g, &expected_tokens);
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_projective_serde_serialization() {
+    use serde_test::{assert_tokens, Token};
+
+    let g = G2Projective::generator();
+    let raw_compressed_bytes = G2Affine::from(g).to_compressed();
+
+    let expected_tokens = std::iter::once(Token::Tuple { len: 96 })
+        .chain(raw_compressed_bytes.iter().map(|&b| Token::U8(b)))
+        .chain(std::iter::once(Token::TupleEnd))
+        .collect::<alloc::vec::Vec<_>>();
+
+    assert_tokens(&g, &expected_tokens);
 }


### PR DESCRIPTION
Inspired by https://github.com/zkcrypto/bls12_381/issues/35 and subsequently https://github.com/zkcrypto/bls12_381/pull/38, this pull request introduces feature-gated serde support for the following:

- `Scalar`
- `G1Affine` and `G1Projective`
- `G2Affine` and `G2Projective`

Where applicable, the compressed form is used over the uncompressed variant.