### PR TITLE
Implement Zeroize for public types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --verbose --release --tests --features endo,experimental
+          args: --verbose --release --tests --features endo,experimental,zeroize
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --release --features endo,experimental
+          args: --verbose --release --features endo,experimental,zeroize
       - name: Build tests (no endomorphism)
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,8 @@ version = "2.2.1"
 default-features = false
 
 [dependencies.zeroize]
-version = "1.3"
+version = "1.4"
 default-features = false
-features = ["zeroize_derive"]
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ default = ["groups", "pairings", "alloc", "bits", "endo"]
 bits = ["ff/bits"]
 groups = ["group"]
 pairings = ["groups", "pairing"]
-alloc = ["group/alloc", "zeroize/alloc"]
+alloc = ["group/alloc"]
 experimental = ["digest"]
 nightly = ["subtle/nightly"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,18 @@ default-features = false
 version = "2.2.1"
 default-features = false
 
+[dependencies.zeroize]
+version = "1.3"
+default-features = false
+features = ["zeroize_derive"]
+optional = true
+
 [features]
 default = ["groups", "pairings", "alloc", "bits", "endo"]
 bits = ["ff/bits"]
 groups = ["group"]
 pairings = ["groups", "pairing"]
-alloc = ["group/alloc"]
+alloc = ["group/alloc", "zeroize/alloc"]
 experimental = ["digest"]
 nightly = ["subtle/nightly"]
 

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -7,11 +7,15 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 use crate::util::{adc, mac, sbb};
 
 // The internal representation of this type is six 64-bit unsigned
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod p, with R = 2^384.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone)]
 pub struct Fp(pub(crate) [u64; 6]);
 

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -7,15 +7,11 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
-
 use crate::util::{adc, mac, sbb};
 
 // The internal representation of this type is six 64-bit unsigned
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod p, with R = 2^384.
-#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone)]
 pub struct Fp(pub(crate) [u64; 6]);
 
@@ -35,6 +31,9 @@ impl Default for Fp {
         Fp::zero()
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Fp {}
 
 impl ConstantTimeEq for Fp {
     fn ct_eq(&self, other: &Self) -> Choice {
@@ -917,4 +916,14 @@ fn test_lexicographic_largest() {
         ])
         .lexicographically_largest()
     ));
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Fp::one();
+    a.zeroize();
+    assert_eq!(a, Fp::zero());
 }

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -9,11 +9,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "pairings")]
 use rand_core::RngCore;
 
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
-
 /// This represents an element $c_0 + c_1 w$ of $\mathbb{F}_{p^12} = \mathbb{F}_{p^6} / w^2 - v$.
-#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Fp12 {
     pub c0: Fp6,
     pub c1: Fp6,
@@ -65,6 +61,9 @@ impl Default for Fp12 {
         Fp12::zero()
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Fp12 {}
 
 impl fmt::Debug for Fp12 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -647,4 +646,14 @@ fn test_arithmetic() {
             .frobenius_map()
             .frobenius_map()
     );
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Fp12::one();
+    a.zeroize();
+    assert_eq!(a, Fp12::zero());
 }

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -9,7 +9,11 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "pairings")]
 use rand_core::RngCore;
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 /// This represents an element $c_0 + c_1 w$ of $\mathbb{F}_{p^12} = \mathbb{F}_{p^6} / w^2 - v$.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Fp12 {
     pub c0: Fp6,
     pub c1: Fp6,

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -5,12 +5,8 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
-
 use crate::fp::Fp;
 
-#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone)]
 pub struct Fp2 {
     pub c0: Fp,
@@ -28,6 +24,9 @@ impl Default for Fp2 {
         Fp2::zero()
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Fp2 {}
 
 impl From<Fp> for Fp2 {
     fn from(f: Fp) -> Fp2 {
@@ -893,4 +892,14 @@ fn test_lexicographic_largest() {
         }
         .lexicographically_largest()
     ));
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Fp2::one();
+    a.zeroize();
+    assert_eq!(a, Fp2::zero());
 }

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -5,8 +5,12 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 use crate::fp::Fp;
 
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone)]
 pub struct Fp2 {
     pub c0: Fp,

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -8,7 +8,11 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "pairings")]
 use rand_core::RngCore;
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 /// This represents an element $c_0 + c_1 v + c_2 v^2$ of $\mathbb{F}_{p^6} = \mathbb{F}_{p^2} / v^3 - u - 1$.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Fp6 {
     pub c0: Fp2,
     pub c1: Fp2,

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -8,11 +8,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "pairings")]
 use rand_core::RngCore;
 
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
-
 /// This represents an element $c_0 + c_1 v + c_2 v^2$ of $\mathbb{F}_{p^6} = \mathbb{F}_{p^2} / v^3 - u - 1$.
-#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct Fp6 {
     pub c0: Fp2,
     pub c1: Fp2,
@@ -58,6 +54,9 @@ impl Default for Fp6 {
         Fp6::zero()
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Fp6 {}
 
 impl fmt::Debug for Fp6 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -517,4 +516,14 @@ fn test_arithmetic() {
         (a * b).invert().unwrap()
     );
     assert_eq!(a.invert().unwrap() * a, Fp6::one());
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Fp6::one();
+    a.zeroize();
+    assert_eq!(a, Fp6::zero());
 }

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -14,6 +14,9 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "alloc")]
 use group::WnafGroup;
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 use crate::fp::Fp;
 use crate::Scalar;
 
@@ -164,6 +167,16 @@ where
         I: Iterator<Item = T>,
     {
         iter.fold(Self::identity(), |acc, item| acc + item.borrow())
+    }
+}
+
+#[cfg(feature = "zeroize")]
+// manual implementation because 'subtle' doesn't have a zeroize feature
+impl Zeroize for G1Affine {
+    fn zeroize(&mut self) {
+        self.x.zeroize();
+        self.y.zeroize();
+        self.infinity = Choice::from(0);
     }
 }
 
@@ -417,6 +430,7 @@ impl G1Affine {
 
 /// This is an element of $\mathbb{G}_1$ represented in the projective coordinate space.
 #[cfg_attr(docsrs, doc(cfg(feature = "groups")))]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone, Debug)]
 pub struct G1Projective {
     pub(crate) x: Fp,
@@ -811,6 +825,7 @@ impl G1Projective {
     }
 }
 
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct G1Compressed([u8; 48]);
 
 impl fmt::Debug for G1Compressed {
@@ -837,6 +852,7 @@ impl AsMut<[u8]> for G1Compressed {
     }
 }
 
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct G1Uncompressed([u8; 96]);
 
 impl fmt::Debug for G1Uncompressed {

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -14,6 +14,9 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "alloc")]
 use group::WnafGroup;
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 use crate::fp::Fp;
 use crate::fp2::Fp2;
 use crate::Scalar;
@@ -165,6 +168,16 @@ where
         I: Iterator<Item = T>,
     {
         iter.fold(Self::identity(), |acc, item| acc + item.borrow())
+    }
+}
+
+#[cfg(feature = "zeroize")]
+// manual implementation because 'subtle' doesn't have a zeroize feature
+impl Zeroize for G2Affine {
+    fn zeroize(&mut self) {
+        self.x.zeroize();
+        self.y.zeroize();
+        self.infinity = Choice::from(0);
     }
 }
 
@@ -491,6 +504,7 @@ impl G2Affine {
 
 /// This is an element of $\mathbb{G}_2$ represented in the projective coordinate space.
 #[cfg_attr(docsrs, doc(cfg(feature = "groups")))]
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Copy, Clone, Debug)]
 pub struct G2Projective {
     pub(crate) x: Fp2,
@@ -999,6 +1013,7 @@ impl G2Projective {
     }
 }
 
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct G2Compressed([u8; 96]);
 
 impl fmt::Debug for G2Compressed {
@@ -1025,6 +1040,7 @@ impl AsMut<[u8]> for G2Compressed {
     }
 }
 
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct G2Uncompressed([u8; 192]);
 
 impl fmt::Debug for G2Uncompressed {

--- a/src/hash_to_curve/expand_msg.rs
+++ b/src/hash_to_curve/expand_msg.rs
@@ -287,13 +287,13 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
     use super::*;
     use sha2::{Sha256, Sha512};
     use sha3::{Shake128, Shake256};
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_xmd_long_dst() {
         const MESSAGE: &[u8] = b"test expand xmd input message";
@@ -310,7 +310,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_xof_long_dst() {
         const MESSAGE: &[u8] = b"test expand xof input message";
@@ -333,7 +332,6 @@ mod tests {
     // These test vectors are consistent between draft 8 and draft 11.
 
     /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.1>
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_message_xmd_works_for_draft8_testvectors_sha256() {
         let dst = b"QUUX-V01-CS02-with-expander";
@@ -440,7 +438,6 @@ mod tests {
     }
 
     /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.2>
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_message_xmd_works_for_draft8_testvectors_sha512() {
         let dst = b"QUUX-V01-CS02-with-expander";
@@ -547,7 +544,6 @@ mod tests {
     }
 
     /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.3>
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_message_xof_works_for_draft8_testvectors_shake128() {
         let dst = b"QUUX-V01-CS02-with-expander";
@@ -654,7 +650,6 @@ mod tests {
     }
 
     /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-11#appendix-K.4>
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_message_xof_works_for_draft11_testvectors_shake256() {
         let dst = b"QUUX-V01-CS02-with-expander";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,10 +77,7 @@ const BLS_X_IS_NEGATIVE: bool = true;
 mod pairings;
 
 #[cfg(feature = "pairings")]
-pub use pairings::{pairing, Bls12, Gt, MillerLoopResult};
-
-#[cfg(all(feature = "pairings", feature = "alloc"))]
-pub use pairings::{multi_miller_loop, G2Prepared};
+pub use pairings::{multi_miller_loop, pairing, Bls12, G2Prepared, Gt, MillerLoopResult};
 
 /// Use the generic_array re-exported by digest to avoid a version mismatch
 #[cfg(feature = "experimental")]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -15,6 +15,9 @@ use core::convert::TryInto;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
+#[cfg(feature = "zeroize")]
+use zeroize::Zeroize;
+
 use crate::util::{adc, mac, sbb};
 
 /// Represents an element of the scalar field $\mathbb{F}_q$ of the BLS12-381 elliptic
@@ -22,6 +25,7 @@ use crate::util::{adc, mac, sbb};
 // The internal representation of this type is four 64-bit unsigned
 // integers in little-endian order. `Scalar` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod q, with R = 2^256.
+#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Clone, Copy, Eq)]
 pub struct Scalar(pub(crate) [u64; 4]);
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -15,9 +15,6 @@ use core::convert::TryInto;
 #[cfg(feature = "bits")]
 use ff::{FieldBits, PrimeFieldBits};
 
-#[cfg(feature = "zeroize")]
-use zeroize::Zeroize;
-
 use crate::util::{adc, mac, sbb};
 
 /// Represents an element of the scalar field $\mathbb{F}_q$ of the BLS12-381 elliptic
@@ -25,7 +22,6 @@ use crate::util::{adc, mac, sbb};
 // The internal representation of this type is four 64-bit unsigned
 // integers in little-endian order. `Scalar` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod q, with R = 2^256.
-#[cfg_attr(feature = "zeroize", derive(Zeroize))]
 #[derive(Clone, Copy, Eq)]
 pub struct Scalar(pub(crate) [u64; 4]);
 
@@ -210,6 +206,9 @@ impl Default for Scalar {
         Self::zero()
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Scalar {}
 
 impl Scalar {
     /// Returns zero, the additive identity.

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1243,3 +1243,18 @@ fn test_double() {
 
     assert_eq!(a.double(), a + a);
 }
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Scalar::from_raw([
+        0x1fff_3231_233f_fffd,
+        0x4884_b7fa_0003_4802,
+        0x998c_4fef_ecbc_4ff3,
+        0x1824_b159_acc5_0562,
+    ]);
+    a.zeroize();
+    assert_eq!(a, Scalar::zero());
+}


### PR DESCRIPTION
Previous discussion/work: https://github.com/zkcrypto/bls12_381/pull/26

This makes `zeroize` an optional feature, and does not automatically zeroize any types on drop.

Fixes #14 