### PR TITLE
Enhance MillerLoopResult API

### DIFF
--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -32,6 +32,12 @@ impl ConditionallySelectable for MillerLoopResult {
 }
 
 impl MillerLoopResult {
+    /// Return Fp12::one() as default value for MillerLoopResult for external library
+    /// accumulation purposes.
+    pub fn default() -> Self {
+        MillerLoopResult(Fp12::one())
+    }
+
     /// This performs a "final exponentiation" routine to convert the result
     /// of a Miller loop into an element of `Gt` with help of efficient squaring
     /// operation in the so-called `cyclotomic subgroup` of `Fq6` so that
@@ -173,6 +179,16 @@ impl<'a, 'b> Add<&'b MillerLoopResult> for &'a MillerLoopResult {
     #[inline]
     fn add(self, rhs: &'b MillerLoopResult) -> MillerLoopResult {
         MillerLoopResult(self.0 * rhs.0)
+    }
+}
+
+/// Allow multiplying two MillerLoopResults by multiplying their internal Fp12 values
+impl<'a, 'b> Mul<&'b MillerLoopResult> for &'a MillerLoopResult {
+    type Output = MillerLoopResult;
+
+    #[inline]
+    fn mul(self, other: &'b MillerLoopResult) -> Self::Output {
+        MillerLoopResult(self.0 * other.0)
     }
 }
 


### PR DESCRIPTION
Changes:

- Expose `default` fun for `MillerLoopResult`
- Allow multiplying `MillerLoopResult` with another `MillerLoopResult`

Context:

I have been tinkering with this library a bit to test signature aggregation and I noticed that it would make it _much_ easier if this library exposed a `default` `MillerLoopResult` (I can rename it to `one` if required) and also allow multiplying two `MillerLoopResult`s together (mostly just to make external use slightly friendlier).

[Here's](https://github.com/vihu/rust-tc/blob/main/src/sig.rs#L79) an example of the way I'm using it but I figured that perhaps it might be helpful for others if I open this up.

There's at least a couple issues: #68 and #67 where this work may prove useful.