### PR TITLE
Add zeroize::Zeroize support for most public types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --verbose --release --tests --features endo,experimental
+          args: --verbose --release --tests --features endo,experimental,zeroize
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --release --features endo,experimental
+          args: --verbose --release --features endo,experimental,zeroize
       - name: Build tests (no endomorphism)
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,11 @@ default-features = false
 version = "2.2.1"
 default-features = false
 
+[dependencies.zeroize]
+version = "1.4"
+default-features = false
+optional = true
+
 [features]
 default = ["groups", "pairings", "alloc", "bits", "endo"]
 bits = ["ff/bits"]

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -925,5 +925,5 @@ fn test_zeroize() {
 
     let mut a = Fp::one();
     a.zeroize();
-    assert_eq!(a, Fp::zero());
+    assert!(bool::from(a.is_zero()));
 }

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -32,6 +32,9 @@ impl Default for Fp {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Fp {}
+
 impl ConstantTimeEq for Fp {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0[0].ct_eq(&other.0[0])
@@ -913,4 +916,14 @@ fn test_lexicographic_largest() {
         ])
         .lexicographically_largest()
     ));
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Fp::one();
+    a.zeroize();
+    assert_eq!(a, Fp::zero());
 }

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -62,6 +62,9 @@ impl Default for Fp12 {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Fp12 {}
+
 impl fmt::Debug for Fp12 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?} + ({:?})*w", self.c0, self.c1)
@@ -643,4 +646,14 @@ fn test_arithmetic() {
             .frobenius_map()
             .frobenius_map()
     );
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Fp12::one();
+    a.zeroize();
+    assert_eq!(a, Fp12::zero());
 }

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -655,5 +655,5 @@ fn test_zeroize() {
 
     let mut a = Fp12::one();
     a.zeroize();
-    assert_eq!(a, Fp12::zero());
+    assert!(bool::from(a.is_zero()));
 }

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -25,6 +25,9 @@ impl Default for Fp2 {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Fp2 {}
+
 impl From<Fp> for Fp2 {
     fn from(f: Fp) -> Fp2 {
         Fp2 {
@@ -889,4 +892,14 @@ fn test_lexicographic_largest() {
         }
         .lexicographically_largest()
     ));
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Fp2::one();
+    a.zeroize();
+    assert_eq!(a, Fp2::zero());
 }

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -901,5 +901,5 @@ fn test_zeroize() {
 
     let mut a = Fp2::one();
     a.zeroize();
-    assert_eq!(a, Fp2::zero());
+    assert!(bool::from(a.is_zero()));
 }

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -55,6 +55,9 @@ impl Default for Fp6 {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Fp6 {}
+
 impl fmt::Debug for Fp6 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?} + ({:?})*v + ({:?})*v^2", self.c0, self.c1, self.c2)
@@ -513,4 +516,14 @@ fn test_arithmetic() {
         (a * b).invert().unwrap()
     );
     assert_eq!(a.invert().unwrap() * a, Fp6::one());
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Fp6::one();
+    a.zeroize();
+    assert_eq!(a, Fp6::zero());
 }

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -525,5 +525,5 @@ fn test_zeroize() {
 
     let mut a = Fp6::one();
     a.zeroize();
-    assert_eq!(a, Fp6::zero());
+    assert!(bool::from(a.is_zero()));
 }

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -1680,11 +1680,11 @@ fn test_zeroize() {
 
     let mut a = G1Affine::generator();
     a.zeroize();
-    assert_eq!(a, G1Affine::identity());
+    assert!(bool::from(a.is_identity()));
 
     let mut a = G1Projective::generator();
     a.zeroize();
-    assert_eq!(a, G1Projective::identity());
+    assert!(bool::from(a.is_identity()));
 
     let mut a = GroupEncoding::to_bytes(&G1Affine::generator());
     a.zeroize();

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -2144,11 +2144,11 @@ fn test_zeroize() {
 
     let mut a = G2Affine::generator();
     a.zeroize();
-    assert_eq!(a, G2Affine::identity());
+    assert!(bool::from(a.is_identity()));
 
     let mut a = G2Projective::generator();
     a.zeroize();
-    assert_eq!(a, G2Projective::identity());
+    assert!(bool::from(a.is_identity()));
 
     let mut a = GroupEncoding::to_bytes(&G2Affine::generator());
     a.zeroize();

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -38,6 +38,9 @@ impl Default for G2Affine {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for G2Affine {}
+
 impl fmt::Display for G2Affine {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
@@ -503,6 +506,9 @@ impl Default for G2Projective {
         G2Projective::identity()
     }
 }
+
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for G2Projective {}
 
 impl fmt::Display for G2Projective {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -999,6 +1005,7 @@ impl G2Projective {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct G2Compressed([u8; 96]);
 
 impl fmt::Debug for G2Compressed {
@@ -1013,6 +1020,9 @@ impl Default for G2Compressed {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for G2Compressed {}
+
 impl AsRef<[u8]> for G2Compressed {
     fn as_ref(&self) -> &[u8] {
         &self.0
@@ -1025,6 +1035,21 @@ impl AsMut<[u8]> for G2Compressed {
     }
 }
 
+impl ConstantTimeEq for G2Compressed {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+impl Eq for G2Compressed {}
+impl PartialEq for G2Compressed {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        bool::from(self.ct_eq(other))
+    }
+}
+
+#[derive(Clone, Copy)]
 pub struct G2Uncompressed([u8; 192]);
 
 impl fmt::Debug for G2Uncompressed {
@@ -1039,6 +1064,9 @@ impl Default for G2Uncompressed {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for G2Uncompressed {}
+
 impl AsRef<[u8]> for G2Uncompressed {
     fn as_ref(&self) -> &[u8] {
         &self.0
@@ -1048,6 +1076,20 @@ impl AsRef<[u8]> for G2Uncompressed {
 impl AsMut<[u8]> for G2Uncompressed {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
+    }
+}
+
+impl ConstantTimeEq for G2Uncompressed {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+impl Eq for G2Uncompressed {}
+impl PartialEq for G2Uncompressed {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        bool::from(self.ct_eq(other))
     }
 }
 
@@ -2093,4 +2135,26 @@ fn test_batch_normalize() {
             }
         }
     }
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = G2Affine::generator();
+    a.zeroize();
+    assert_eq!(a, G2Affine::identity());
+
+    let mut a = G2Projective::generator();
+    a.zeroize();
+    assert_eq!(a, G2Projective::identity());
+
+    let mut a = GroupEncoding::to_bytes(&G2Affine::generator());
+    a.zeroize();
+    assert_eq!(&a, &G2Compressed::default());
+
+    let mut a = UncompressedEncoding::to_uncompressed(&G2Affine::generator());
+    a.zeroize();
+    assert_eq!(&a, &G2Uncompressed::default());
 }

--- a/src/hash_to_curve/expand_msg.rs
+++ b/src/hash_to_curve/expand_msg.rs
@@ -287,13 +287,13 @@ where
     }
 }
 
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
     use super::*;
     use sha2::{Sha256, Sha512};
     use sha3::{Shake128, Shake256};
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_xmd_long_dst() {
         const MESSAGE: &[u8] = b"test expand xmd input message";
@@ -310,7 +310,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_xof_long_dst() {
         const MESSAGE: &[u8] = b"test expand xof input message";
@@ -333,7 +332,6 @@ mod tests {
     // These test vectors are consistent between draft 8 and draft 11.
 
     /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.1>
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_message_xmd_works_for_draft8_testvectors_sha256() {
         let dst = b"QUUX-V01-CS02-with-expander";
@@ -440,7 +438,6 @@ mod tests {
     }
 
     /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.2>
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_message_xmd_works_for_draft8_testvectors_sha512() {
         let dst = b"QUUX-V01-CS02-with-expander";
@@ -547,7 +544,6 @@ mod tests {
     }
 
     /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.3>
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_message_xof_works_for_draft8_testvectors_shake128() {
         let dst = b"QUUX-V01-CS02-with-expander";
@@ -654,7 +650,6 @@ mod tests {
     }
 
     /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-11#appendix-K.4>
-    #[cfg(feature = "alloc")]
     #[test]
     fn expand_message_xof_works_for_draft11_testvectors_shake256() {
         let dst = b"QUUX-V01-CS02-with-expander";

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -31,6 +31,9 @@ impl Default for MillerLoopResult {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for MillerLoopResult {}
+
 impl ConditionallySelectable for MillerLoopResult {
     fn conditional_select(a: &Self, b: &Self, choice: Choice) -> Self {
         MillerLoopResult(Fp12::conditional_select(&a.0, &b.0, choice))
@@ -914,6 +917,19 @@ fn test_miller_loop_result_default() {
         MillerLoopResult::default().final_exponentiation(),
         Gt::identity(),
     );
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_miller_loop_result_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut m = multi_miller_loop(&[
+        (&G1Affine::generator(), &G2Affine::generator().into()),
+        (&-G1Affine::generator(), &G2Affine::generator().into()),
+    ]);
+    m.zeroize();
+    assert_eq!(m.0, MillerLoopResult::default().0);
 }
 
 #[test]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -207,6 +207,9 @@ impl Default for Scalar {
     }
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::DefaultIsZeroes for Scalar {}
+
 impl Scalar {
     /// Returns zero, the additive identity.
     #[inline]
@@ -1239,4 +1242,19 @@ fn test_double() {
     ]);
 
     assert_eq!(a.double(), a + a);
+}
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn test_zeroize() {
+    use zeroize::Zeroize;
+
+    let mut a = Scalar::from_raw([
+        0x1fff_3231_233f_fffd,
+        0x4884_b7fa_0003_4802,
+        0x998c_4fef_ecbc_4ff3,
+        0x1824_b159_acc5_0562,
+    ]);
+    a.zeroize();
+    assert_eq!(a, Scalar::zero());
 }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1256,5 +1256,5 @@ fn test_zeroize() {
         0x1824_b159_acc5_0562,
     ]);
     a.zeroize();
-    assert_eq!(a, Scalar::zero());
+    assert!(bool::from(a.is_zero()));
 }


### PR DESCRIPTION
Previous discussion/work: #26

This makes zeroize an optional feature, and does not automatically zeroize any types on drop.

Fixes #14 (supersedes #63)