### PR TITLE
Unit test updates for hash-to-curve draft 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This crate provides an implementation of the BLS12-381 pairing-friendly elliptic
 * `alloc` (on by default): Enables APIs that require an allocator; these include pairing optimizations.
 * `nightly`: Enables `subtle/nightly` which tries to prevent compiler optimizations that could jeopardize constant time operations. Requires the nightly Rust compiler.
 * `experimental`: Enables experimental features. These features have no backwards-compatibility guarantees and may change at any time; users that depend on specific behaviour should pin an exact version of this crate. The current list of experimental features:
-  * Hashing to curves ([Internet Draft v11](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11))
+  * Hashing to curves ([Internet Draft v12](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12))
 
 ## [Documentation](https://docs.rs/bls12_381)
 

--- a/src/hash_to_curve/expand_msg.rs
+++ b/src/hash_to_curve/expand_msg.rs
@@ -20,9 +20,9 @@ const OVERSIZE_DST_SALT: &[u8] = b"H2C-OVERSIZE-DST-";
 
 /// The domain separation tag for a message expansion.
 ///
-/// Implements [section 5.4.3 of `draft-irtf-cfrg-hash-to-curve-11`][dst].
+/// Implements [section 5.4.3 of `draft-irtf-cfrg-hash-to-curve-12`][dst].
 ///
-/// [dst]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-5.4.3
+/// [dst]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-5.4.3
 #[derive(Debug)]
 enum ExpandMsgDst<'x, L: ArrayLength<u8>> {
     /// DST produced by hashing a very long (> 255 chars) input DST.
@@ -120,10 +120,10 @@ pub trait ExpandMessageState<'x> {
 /// A generator for the output of `expand_message_xof` for a given
 /// extendable hash function, message, DST, and output length.
 ///
-/// Implements [section 5.4.2 of `draft-irtf-cfrg-hash-to-curve-11`][expand_message_xof]
+/// Implements [section 5.4.2 of `draft-irtf-cfrg-hash-to-curve-12`][expand_message_xof]
 /// with `k = 128`.
 ///
-/// [expand_message_xof]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-5.4.2
+/// [expand_message_xof]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-5.4.2
 pub struct ExpandMsgXof<H: ExtendableOutputDirty> {
     hash: <H as ExtendableOutputDirty>::Reader,
     remain: usize,
@@ -178,18 +178,18 @@ where
 /// Constructor for `expand_message_xmd` for a given digest hash function, message, DST,
 /// and output length.
 ///
-/// Implements [section 5.4.1 of `draft-irtf-cfrg-hash-to-curve-11`][expand_message_xmd].
+/// Implements [section 5.4.1 of `draft-irtf-cfrg-hash-to-curve-12`][expand_message_xmd].
 ///
-/// [expand_message_xmd]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-5.4.1
+/// [expand_message_xmd]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-5.4.1
 #[derive(Debug)]
 pub struct ExpandMsgXmd<H: Digest>(PhantomData<H>);
 
 /// A generator for the output of `expand_message_xmd` for a given
 /// digest hash function, message, DST, and output length.
 ///
-/// Implements [section 5.4.1 of `draft-irtf-cfrg-hash-to-curve-11`][expand_message_xmd].
+/// Implements [section 5.4.1 of `draft-irtf-cfrg-hash-to-curve-12`][expand_message_xmd].
 ///
-/// [expand_message_xmd]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-5.4.1
+/// [expand_message_xmd]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-5.4.1
 pub struct ExpandMsgXmdState<'x, H: Digest> {
     dst: ExpandMsgDst<'x, H::OutputSize>,
     b_0: GenericArray<u8, H::OutputSize>,
@@ -294,53 +294,18 @@ mod tests {
     use sha2::{Sha256, Sha512};
     use sha3::{Shake128, Shake256};
 
+    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.1>
     #[test]
-    fn expand_xmd_long_dst() {
-        const MESSAGE: &[u8] = b"test expand xmd input message";
-        const LONG_DST: &[u8] = b"test expand xmd long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long dst";
-
-        const EXPECT: &[(usize, &str)] = &[
-            (10, "417ab5fec8c0afa8492b"),
-            (100, "e70f11136df2be4ce806586e187437a23647be319ed4095032c776b81291905cfccd644d9123f91f18a960936956b851390f61f02785b1aa5ba1d192afce2745afe789933f0e1964eedd4e83e060d1004dea7467db044b589eb14c75b6fc75ed3f2759c7"),
-            (1000, "dfff931bf2ca85308ae1baf5a3cae59fb9c2559d0ce1cf7232fbcf208938c5fa3f40186e8db05fdba3f1435491a934f466b7cacf0a5264f7cf958b331973bd7a09e04acd7e608f34f31fce54497a3dd16a6480448abb829ce63726cc9ac2ce22972c26808f11c3e0f8aa3a8a4074bd4ed015a1c20619972262a97b432105a6d11a969651ca239447cb2396a12821cc49de691140aaa882182587803333df94a57690048cf4dce7693cce54777fd5f492ac7881865a6ff889428a90be4083257cf236162e907bac6f4ded45ed745b7c986346eb8582b78fabc649d90277a6021df6fee85532d93bd125d8b61dbcae284486a5bc7c27f9e60a9faf536cdd291c63fc5661ae5415b39882ff6f0659ec8dbc524cf24929496c45fd7dd6e2769045868e0f1e9ce132c5d4e9b24ea9a9ef99178684113d4e77466e8bf95b0925b323db9a8d5782e67b4e7dfe5d233e3d1e305373c9d78ccd3d94f96b576cda18dac4df5a41266228d168f9cbb60cc2161976d2599b8532b554f10e0072bc229c8bda69b2a2521cf0fa79792454e76adbd145e962b185284e908ca45d4595deb392bed197de5cfe5dd5b05510454ac37a3fdc52862844a68e9b5a97219b614132d262c7cf51f8ad410419f62b80f3be4caa55d450ba573a0602116f06c1dda86898042c9a8617ae83f36357f3fa4e3ba930efa8a61fcd51b1a218789d423f135610fb1c1d15ca9a07ced8b043984870d3e42cfba6362cf7b2d3bc64690f14d0ad5ebaf9b20b00fe98de4b469a451a82177eff1fd584a74cfd9c0294686ed152987d598df944d5c8bd68c5a977b8dd33f9af706ba72eaaeae6e6d3d69374a4096281c21f8d8a97141c627967cdf9a2c540e2c95be91614fa69e7db12488e0c439a20aab50f21fd114d3679a2b1245115ddbead473ddc1fe4736c7f368c416a409160848a8d450ab2a7f24f00c8b1f2bc75b4553f4fb2e4e61c1da4ec7a112d5b2c1cf8245f875a52e195665eb5d43ca23e35ec306f25c5e0dfc90366b320db4c9ef1c7af86d7e7c142700fdea52a3288bbff36f49b856b8b012a7b313025b1afa08928c0406effb3d8c5f8903611ba6be55cfad7c527efcda87765d9adc8114fc25e91e64b1f13c76cb01f4d0b50e39d83c9ba211188788bb6d7af51087a00daf0c2dc037e0105e0e5fa20aa1da75e86ef479ad67e01c36afe55d4532726810ae3668c17a1c029d312ee06c356e8fdd37eef01b41c5d8d4828ccae0fb7efb2c1d51059c63b311deb480f2e6c1e42cf315942a0bdbe515471412ba47f78fdca81d5e5fcbb3a207a51c94f306dd4551e0743d3e7f9f48c1b758772b3fe09df98bf857dee124c609f570566cc73cf4746defcc6a8c77c9dad4928911e5e712fb5c90fab41791229b6f8b56fa633")
-        ];
-        for (len, hexpect) in EXPECT {
-            let data = ExpandMsgXmd::<Sha256>::init_expand(MESSAGE, LONG_DST, *len).into_vec();
-            assert_eq!(&hex::encode(&data), hexpect);
-        }
-    }
-
-    #[test]
-    fn expand_xof_long_dst() {
-        const MESSAGE: &[u8] = b"test expand xof input message";
-        const LONG_DST: &[u8] = b"test expand xof long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long dst";
-
-        const EXPECT: &[(usize, &str)] = &[
-            (10, "b00df0c3074566d72091"),
-            (100, "d228fba4aef7bdbe1960975d00734fecde2c1366c014588a28a4084c23b10ac97429df7953cbe811d224ec6d7b76aca88e8b00e50a7ced97e2fbd02b5cc652eb0cff3cbbb4dff1569f84576c6ae127bc3649534c8771a004aef6af08ff9e4ec78ebc85f8"),
-            (1000, "8cfd6e04761c87233893639fee0d39358531ea81b79ce545a3f87faa39e41d196ddb5d0755d29d761926eed99265a038584e849e3516c5864849312d33180484e8c75213bc4ea582a5cc55f7b7ecbed89feb2c5799abcc4b87d3627cd84939062de8c9f311e543f3c3c7be2c6ac1441d607209da0640ae3173b1715a2ac0d861c063b5b2be0d85af429afb51a89aa38a25603369955af8c420752eb434a195a0096e9b36218dfa1aab5e6a1cfc140d2be2e91050de9588b2bab05c3ac4b43db91b06483159482daf787562aa417eb886ae9b02a47e8081132fed303fc05ce316e13f4c50eaa09618dc52e77f03dec0424bec634377e857fa3c5f3b39a7695472fb4416fe5c3b4fecebd8d601dbc426ae24b95f8b6baa90b66e79cd4447266d3e9924e57efe903d3fa247c070ede4210d3f836fd0d2313e4832f07d0f9fa2fd28d615e325876cdde509ae75c1bc3c5d0be6881aff0e096cadc3f7d4823ac1ace6ca4f79286bd6d44ad95afcc4950eb26c6823297ab8bf2c6ae7203f4e9d2b35920d85fdb89d2d6120f0901afbed8e9c35794dae30bada9648775ba8dda333cce81be6f63b8cc6e2f686115b37eec11db60706a0a0fa534be88435f761b7f3e42cb6953f8bbcf4a3d2e21a8936af0ba0ab3105d3d780dcf7c4d4934512c32dbb142c5f80f1f5af1ef9f84470956eebf9cdf8a7e0037df7061ed56a8cb030f28d79be37bd72c1cb58883debf62a636e7d56fbcba2df7c5343de80ef79f5db1f02d04ad9c8cffa5ba0752bb106aa94cdacce8c8ce39e8021b9658bd55c1fe1fb7172d5af30c93933662e84ac25c1ba0cfa455782b863ea47029bfc4e78660c647cc21f377e9e5d9d8a94fbaf1087bb3b05a772ec756010beb290a786505832a075238e3899d120ae8c40a721b19e80896bad94746fd69b0e34dd937ae19b663dfee2e9f08678923fa92d66d5dc2c4f461f1eff4b7e8daf6542510a0ded177b38307eb6a4a5b5e3d5218ed752721c8b58a39f33df23a51e0b4b35e10fb2297a2a7590e8af6b587184336152c951bcc314f9d64c298b46e1327a65abe15256df6ff44284d850c392c41b350904da0c82d49bcea7324fb3a4cdc4f1f02f4e7b8da92405eb7e7d83e7bb824029912e9955401229516167700b853a57cd57b6f0ed6d80ab7bda91a49dc471e80d870ff6461c20f0cf5ae6df73181d16a47d20849677291a999578d37fc9ce75d69b1ec38d8d516da808faf09c6f470385d200f4553576f144fcf8f979fea3c98e2672a349cc47cc64dc828237901542b690cff6c54e9ee1d08f4d88a6711c150c139122ae702d6ae1121ddd8cc6a5ad5455980ecfce82a7b717be980ddcb530de526ddddf37711045f97c23963a08ab2ccafabb2e7728448b7c69cedda3ef10")
-        ];
-        for (len, hexpect) in EXPECT {
-            let data = ExpandMsgXof::<Shake128>::init_expand(MESSAGE, LONG_DST, *len).into_vec();
-            assert_eq!(&hex::encode(&data), hexpect);
-        }
-    }
-
-    // Except for internal variables, expand_message_xmd and expand_message_xof did not change
-    // between draft 7 and draft 8:
-    // <https://tools.ietf.org/rfcdiff?difftype=--hwdiff&url2=draft-irtf-cfrg-hash-to-curve-08.txt>
-    // These test vectors are consistent between draft 8 and draft 11.
-
-    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.1>
-    #[test]
-    fn expand_message_xmd_works_for_draft8_testvectors_sha256() {
-        let dst = b"QUUX-V01-CS02-with-expander";
+    fn expand_message_xmd_works_for_draft12_testvectors_sha256() {
+        let dst = b"QUUX-V01-CS02-with-expander-SHA256-128";
 
         let msg = b"";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("f659819a6473c1835b25ea59e3d38914c98b374f0970b7e4c92181df928fca88")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "68a985b87eb6b46952128911f2a4412bbc302a9d759667f8\
+            7f7a21d803f07235",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -348,9 +313,11 @@ mod tests {
 
         let msg = b"abc";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("1c38f7c211ef233367b2420d04798fa4698080a8901021a795a1151775fe4da7")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "d8ccab23b5985ccea865c6c97b6e5b8350e794e603b4b979\
+            02f53a8a0d605615",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -358,29 +325,46 @@ mod tests {
 
         let msg = b"abcdef0123456789";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("8f7e7b66791f0da0dbb5ec7c22ec637f79758c0a48170bfb7c4611bd304ece89")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "eff31487c770a893cfb36f912fbfcbff40d5661771ca4b2c\
+            b4eafe524333f5c1",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
 
-        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("72d5aa5ec810370d1f0013c0df2f1d65699494ee2a39f72e1716b1b964e1c642")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "b23a1d2b4d97b2ef7785562a7e8bac7eed54ed6e97e29aa5\
+            1bfe3f12ddad1ff9",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
 
-        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("3b8e704fc48336aca4c2a12195b720882f2162a4b7b13a9c350db46f429b771b")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "4623227bcc01293b8c130bf771da8c298dede7383243dc09\
+            93d2d94823958c4c",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -388,9 +372,14 @@ mod tests {
 
         let msg = b"";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("8bcffd1a3cae24cf9cd7ab85628fd111bb17e3739d3b53f89580d217aa79526f1708354a76a402d3569d6a9d19ef3de4d0b991e4f54b9f20dcde9b95a66824cbdf6c1a963a1913d43fd7ac443a02fc5d9d8d77e2071b86ab114a9f34150954a7531da568a1ea8c760861c0cde2005afc2c114042ee7b5848f5303f0611cf297f")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "af84c27ccfd45d41914fdff5df25293e221afc53d8ad2ac0\
+            6d5e3e29485dadbee0d121587713a3e0dd4d5e69e93eb7cd4f5df4\
+            cd103e188cf60cb02edc3edf18eda8576c412b18ffb658e3dd6ec8\
+            49469b979d444cf7b26911a08e63cf31f9dcc541708d3491184472\
+            c2c29bb749d4286b004ceb5ee6b9a7fa5b646c993f0ced",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -398,9 +387,14 @@ mod tests {
 
         let msg = b"abc";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("fe994ec51bdaa821598047b3121c149b364b178606d5e72bfbb713933acc29c186f316baecf7ea22212f2496ef3f785a27e84a40d8b299cec56032763eceeff4c61bd1fe65ed81decafff4a31d0198619c0aa0c6c51fca15520789925e813dcfd318b542f8799441271f4db9ee3b8092a7a2e8d5b75b73e28fb1ab6b4573c192")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "abba86a6129e366fc877aab32fc4ffc70120d8996c88aee2\
+            fe4b32d6c7b6437a647e6c3163d40b76a73cf6a5674ef1d890f95b\
+            664ee0afa5359a5c4e07985635bbecbac65d747d3d2da7ec2b8221\
+            b17b0ca9dc8a1ac1c07ea6a1e60583e2cb00058e77b7b72a298425\
+            cd1b941ad4ec65e8afc50303a22c0f99b0509b4c895f40",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -408,151 +402,403 @@ mod tests {
 
         let msg = b"abcdef0123456789";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("c9ec7941811b1e19ce98e21db28d22259354d4d0643e301175e2f474e030d32694e9dd5520dde93f3600d8edad94e5c364903088a7228cc9eff685d7eaac50d5a5a8229d083b51de4ccc3733917f4b9535a819b445814890b7029b5de805bf62b33a4dc7e24acdf2c924e9fe50d55a6b832c8c84c7f82474b34e48c6d43867be")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "ef904a29bffc4cf9ee82832451c946ac3c8f8058ae97d8d6\
+            29831a74c6572bd9ebd0df635cd1f208e2038e760c4994984ce73f\
+            0d55ea9f22af83ba4734569d4bc95e18350f740c07eef653cbb9f8\
+            7910d833751825f0ebefa1abe5420bb52be14cf489b37fe1a72f7d\
+            e2d10be453b2c9d9eb20c7e3f6edc5a60629178d9478df",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
 
-        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("48e256ddba722053ba462b2b93351fc966026e6d6db493189798181c5f3feea377b5a6f1d8368d7453faef715f9aecb078cd402cbd548c0e179c4ed1e4c7e5b048e0a39d31817b5b24f50db58bb3720fe96ba53db947842120a068816ac05c159bb5266c63658b4f000cbf87b1209a225def8ef1dca917bcda79a1e42acd8069")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "80be107d0884f0d881bb460322f0443d38bd222db8bd0b0a\
+            5312a6fedb49c1bbd88fd75d8b9a09486c60123dfa1d73c1cc3169\
+            761b17476d3c6b7cbbd727acd0e2c942f4dd96ae3da5de368d26b3\
+            2286e32de7e5a8cb2949f866a0b80c58116b29fa7fabb3ea7d520e\
+            e603e0c25bcaf0b9a5e92ec6a1fe4e0391d1cdbce8c68a",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
 
-        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("396962db47f749ec3b5042ce2452b619607f27fd3939ece2746a7614fb83a1d097f554df3927b084e55de92c7871430d6b95c2a13896d8a33bc48587b1f66d21b128a1a8240d5b0c26dfe795a1a842a0807bb148b77c2ef82ed4b6c9f7fcb732e7f94466c8b51e52bf378fba044a31f5cb44583a892f5969dcd73b3fa128816e")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "546aff5444b5b79aa6148bd81728704c32decb73a3ba76e9\
+            e75885cad9def1d06d6792f8a7d12794e90efed817d96920d72889\
+            6a4510864370c207f99bd4a608ea121700ef01ed879745ee3e4cee\
+            f777eda6d9e5e38b90c86ea6fb0b36504ba4a45d22e86f6db5dd43\
+            d98a294bebb9125d5b794e9d2a81181066eb954966a487",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-    }
-
-    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.2>
-    #[test]
-    fn expand_message_xmd_works_for_draft8_testvectors_sha512() {
-        let dst = b"QUUX-V01-CS02-with-expander";
-
-        let msg = b"";
-        let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("2eaa1f7b5715f4736e6a5dbe288257abf1faa028680c1d938cd62ac699ead642")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"abc";
-        let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("0eeda81f69376c80c0f8986496f22f21124cb3c562cf1dc608d2c13005553b0f")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"abcdef0123456789";
-        let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("2e375fc05e05e80dbf3083796fde2911789d9e8847e1fcebf4ca4b36e239b338")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
-        let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("c37f9095fe7fe4f01c03c3540c1229e6ac8583b07510085920f62ec66acc0197")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("af57a7f56e9ed2aa88c6eab45c8c6e7638ae02da7c92cc04f6648c874ebd560e")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"";
-        let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("0687ce02eba5eb3faf1c3c539d1f04babd3c0f420edae244eeb2253b6c6d6865145c31458e824b4e87ca61c3442dc7c8c9872b0b7250aa33e0668ccebbd2b386de658ca11a1dcceb51368721ae6dcd2d4bc86eaebc4e0d11fa02ad053289c9b28a03da6c942b2e12c14e88dbde3b0ba619d6214f47212b628f3e1b537b66efcf")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"abc";
-        let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("779ae4fd8a92f365e4df96b9fde97b40486bb005c1a2096c86f55f3d92875d89045fbdbc4a0e9f2d3e1e6bcd870b2d7131d868225b6fe72881a81cc5166b5285393f71d2e68bb0ac603479959370d06bdbe5f0d8bfd9af9494d1e4029bd68ab35a561341dd3f866b3ef0c95c1fdfaab384ce24a23427803dda1db0c7d8d5344a")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"abcdef0123456789";
-        let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("f0953d28846a50e9f88b7ae35b643fc43733c9618751b569a73960c655c068db7b9f044ad5a40d49d91c62302eaa26163c12abfa982e2b5d753049e000adf7630ae117aeb1fb9b61fc724431ac68b369e12a9481b4294384c3c890d576a79264787bc8076e7cdabe50c044130e480501046920ff090c1a091c88391502f0fbac")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
-        let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("64d3e59f0bc3c5e653011c914b419ba8310390a9585311fddb26791d26663bd71971c347e1b5e88ba9274d2445ed9dcf48eea9528d807b7952924159b7c27caa4f25a2ea94df9508e70a7012dfce0e8021b37e59ea21b80aa9af7f1a1f2efa4fbe523c4266ce7d342acaacd438e452c501c131156b4945515e9008d2b155c258")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
-            uniform_bytes
-        );
-
-        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("01524feea5b22f6509f6b1e805c97df94faf4d821b01aadeebc89e9daaed0733b4544e50852fd3e019d58eaad6d267a134c8bc2c08bc46c10bfeff3ee03110bcd8a0d695d75a34092bd8b677bdd369a13325549abab54f4ac907b712bdd3567f38c4554c51902b735b81f43a7ef6f938c7690d107c052c7e7b795ac635b3200a")
-                .unwrap();
-        assert_eq!(
-            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
     }
 
-    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-08#appendix-I.3>
+    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.2>
     #[test]
-    fn expand_message_xof_works_for_draft8_testvectors_shake128() {
-        let dst = b"QUUX-V01-CS02-with-expander";
+    fn expand_message_xmd_works_for_draft12_testvectors_sha256_long_dst() {
+        let dst = b"QUUX-V01-CS02-with-expander-SHA256-128-long-DST-111111\
+            111111111111111111111111111111111111111111111111111111\
+            111111111111111111111111111111111111111111111111111111\
+            111111111111111111111111111111111111111111111111111111\
+            1111111111111111111111111111111111111111";
 
         let msg = b"";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("eca3fe8f7f5f1d52d7ed3691c321adc7d2a0fef1f843d221f7002530070746de")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "e8dc0c8b686b7ef2074086fbdd2f30e3f8bfbd3bdf177f73\
+            f04b97ce618a3ed3",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abc";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "52dbf4f36cf560fca57dedec2ad924ee9c266341d8f3d6af\
+            e5171733b16bbb12",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abcdef0123456789";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "35387dcf22618f3728e6c686490f8b431f76550b0b2c61cb\
+            c1ce7001536f4521",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "01b637612bb18e840028be900a833a74414140dde0c4754c\
+            198532c3a0ba42bc",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "20cce7033cabc5460743180be6fa8aac5a103f56d481cf36\
+            9a8accc0c374431b",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "14604d85432c68b757e485c8894db3117992fc57e0e136f7\
+            1ad987f789a0abc287c47876978e2388a02af86b1e8d1342e5ce4f\
+            7aaa07a87321e691f6fba7e0072eecc1218aebb89fb14a0662322d\
+            5edbd873f0eb35260145cd4e64f748c5dfe60567e126604bcab1a3\
+            ee2dc0778102ae8a5cfd1429ebc0fa6bf1a53c36f55dfc",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abc";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "1a30a5e36fbdb87077552b9d18b9f0aee16e80181d5b951d\
+            0471d55b66684914aef87dbb3626eaabf5ded8cd0686567e503853\
+            e5c84c259ba0efc37f71c839da2129fe81afdaec7fbdc0ccd4c794\
+            727a17c0d20ff0ea55e1389d6982d1241cb8d165762dbc39fb0cee\
+            4474d2cbbd468a835ae5b2f20e4f959f56ab24cd6fe267",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abcdef0123456789";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "d2ecef3635d2397f34a9f86438d772db19ffe9924e28a1ca\
+            f6f1c8f15603d4028f40891044e5c7e39ebb9b31339979ff33a424\
+            9206f67d4a1e7c765410bcd249ad78d407e303675918f20f26ce6d\
+            7027ed3774512ef5b00d816e51bfcc96c3539601fa48ef1c07e494\
+            bdc37054ba96ecb9dbd666417e3de289d4f424f502a982",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "ed6e8c036df90111410431431a232d41a32c86e296c05d42\
+            6e5f44e75b9a50d335b2412bc6c91e0a6dc131de09c43110d9180d\
+            0a70f0d6289cb4e43b05f7ee5e9b3f42a1fad0f31bac6a625b3b5c\
+            50e3a83316783b649e5ecc9d3b1d9471cb5024b7ccf40d41d1751a\
+            04ca0356548bc6e703fca02ab521b505e8e45600508d32",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "78b53f2413f3c688f07732c10e5ced29a17c6a16f717179f\
+            fbe38d92d6c9ec296502eb9889af83a1928cd162e845b0d3c5424e\
+            83280fed3d10cffb2f8431f14e7a23f4c68819d40617589e4c4116\
+            9d0b56e0e3535be1fd71fbb08bb70c5b5ffed953d6c14bf7618b35\
+            fc1f4c4b30538236b4b08c9fbf90462447a8ada60be495",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha256>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+    }
+
+    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.3>
+    #[test]
+    fn expand_message_xmd_works_for_draft12_testvectors_sha512() {
+        let dst = b"QUUX-V01-CS02-with-expander-SHA512-256";
+
+        let msg = b"";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "6b9a7312411d92f921c6f68ca0b6380730a1a4d982c50721\
+            1a90964c394179ba",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abc";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "0da749f12fbe5483eb066a5f595055679b976e93abe9be6f\
+            0f6318bce7aca8dc",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abcdef0123456789";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "087e45a86e2939ee8b91100af1583c4938e0f5fc6c9db4b1\
+            07b83346bc967f58",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "7336234ee9983902440f6bc35b348352013becd88938d2af\
+            ec44311caf8356b3",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "57b5f7e766d5be68a6bfe1768e3c2b7f1228b3e4b3134956\
+            dd73a59b954c66f4",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "41b037d1734a5f8df225dd8c7de38f851efdb45c372887be\
+            655212d07251b921b052b62eaed99b46f72f2ef4cc96bfaf254ebb\
+            bec091e1a3b9e4fb5e5b619d2e0c5414800a1d882b62bb5cd1778f\
+            098b8eb6cb399d5d9d18f5d5842cf5d13d7eb00a7cff859b605da6\
+            78b318bd0e65ebff70bec88c753b159a805d2c89c55961",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abc";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "7f1dddd13c08b543f2e2037b14cefb255b44c83cc397c178\
+            6d975653e36a6b11bdd7732d8b38adb4a0edc26a0cef4bb4521713\
+            5456e58fbca1703cd6032cb1347ee720b87972d63fbf232587043e\
+            d2901bce7f22610c0419751c065922b488431851041310ad659e4b\
+            23520e1772ab29dcdeb2002222a363f0c2b1c972b3efe1",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abcdef0123456789";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "3f721f208e6199fe903545abc26c837ce59ac6fa45733f1b\
+            aaf0222f8b7acb0424814fcb5eecf6c1d38f06e9d0a6ccfbf85ae6\
+            12ab8735dfdf9ce84c372a77c8f9e1c1e952c3a61b7567dd069301\
+            6af51d2745822663d0c2367e3f4f0bed827feecc2aaf98c949b5ed\
+            0d35c3f1023d64ad1407924288d366ea159f46287e61ac",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "b799b045a58c8d2b4334cf54b78260b45eec544f9f2fb5bd\
+            12fb603eaee70db7317bf807c406e26373922b7b8920fa29142703\
+            dd52bdf280084fb7ef69da78afdf80b3586395b433dc66cde048a2\
+            58e476a561e9deba7060af40adf30c64249ca7ddea79806ee5beb9\
+            a1422949471d267b21bc88e688e4014087a0b592b695ed",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "05b0bfef265dcee87654372777b7c44177e2ae4c13a27f10\
+            3340d9cd11c86cb2426ffcad5bd964080c2aee97f03be1ca18e30a\
+            1f14e27bc11ebbd650f305269cc9fb1db08bf90bfc79b42a952b46\
+            daf810359e7bc36452684784a64952c343c52e5124cd1f71d474d5\
+            197fefc571a92929c9084ffe1112cf5eea5192ebff330b",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXmd::<Sha512>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+    }
+
+    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.4>
+    #[test]
+    fn expand_message_xof_works_for_draft12_testvectors_shake128() {
+        let dst = b"QUUX-V01-CS02-with-expander-SHAKE128";
+
+        let msg = b"";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "86518c9cd86581486e9485aa74ab35ba150d1c75c88e26b7\
+            043e44e2acd735a2",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -560,9 +806,11 @@ mod tests {
 
         let msg = b"abc";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("c79b8ea0af10fd8871eda98334ea9d54e9e5282be97521678f987718b187bc08")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "8696af52a4d862417c0763556073f47bc9b9ba43c99b5053\
+            05cb1ec04a9ab468",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -570,29 +818,46 @@ mod tests {
 
         let msg = b"abcdef0123456789";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("fb6f4af2a83f6276e9d41784f1e29da5e27566167c33e5cf2682c30096878b73")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "912c58deac4821c3509dbefa094df54b34b8f5d01a191d1d\
+            3108a2c89077acca",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
 
-        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("125d05850db915e0683d17d044d87477e6e7b3f70a450dd097761e18d1d1dcdf")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "1adbcc448aef2a0cebc71dac9f756b22e51839d348e031e6\
+            3b33ebb50faeaf3f",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
 
-        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("beafd026cb942c86f6a2b31bb8e6bf7173fb1b0caf3c21ea4b3b9d05d904fd23")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "df3447cc5f3e9a77da10f819218ddf31342c310778e0e4ef\
+            72bbaecee786a4fe",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -600,9 +865,14 @@ mod tests {
 
         let msg = b"";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("15733b3fb22fac0e0902c220aeea48e5e47d39f36c2cc03eac34367c48f2a3ebbcb3baa8a0cf17ab12fff4defc7ce22aed47188b6c163e828741473bd89cc646a082cb68b8e835b1374ea9a6315d61db0043f4abf506c26386e84668e077c85ebd9d632f4390559b979e70e9e7affbd0ac2a212c03b698efbbe940f2d164732b")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "7314ff1a155a2fb99a0171dc71b89ab6e3b2b7d59e38e644\
+            19b8b6294d03ffee42491f11370261f436220ef787f8f76f5b26bd\
+            cd850071920ce023f3ac46847744f4612b8714db8f5db83205b2e6\
+            25d95afd7d7b4d3094d3bdde815f52850bb41ead9822e08f22cf41\
+            d615a303b0d9dde73263c049a7b9898208003a739a2e57",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -610,9 +880,14 @@ mod tests {
 
         let msg = b"abc";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("4ccafb6d95b91537798d1fbb25b9fbe1a5bbe1683f43a4f6f03ef540b811235317bfc0aefb217faca055e1b8f32dfde9eb102cdc026ed27caa71530e361b3adbb92ccf68da35aed8b9dc7e4e6b5db0666c607a31df05513ddaf4c8ee23b0ee7f395a6e8be32eb13ca97da289f2643616ac30fe9104bb0d3a67a0a525837c2dc6")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "c952f0c8e529ca8824acc6a4cab0e782fc3648c563ddb00d\
+            a7399f2ae35654f4860ec671db2356ba7baa55a34a9d7f79197b60\
+            ddae6e64768a37d699a78323496db3878c8d64d909d0f8a7de4927\
+            dcab0d3dbbc26cb20a49eceb0530b431cdf47bc8c0fa3e0d88f53b\
+            318b6739fbed7d7634974f1b5c386d6230c76260d5337a",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -620,45 +895,240 @@ mod tests {
 
         let msg = b"abcdef0123456789";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("c8ee0e12736efbc9b47781db9d1e5db9c853684344a6776eb362d75b354f4b74cf60ba1373dc2e22c68efb76a022ed5391f67c77990802018c8cdc7af6d00c86b66a3b3ccad3f18d90f4437a165186f6601cf0bb281ea5d80d1de20fe22bb2e2d8acab0c043e76e3a0f34e0a1e66c9ade4fef9ef3b431130ad6f232babe9fe68")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "19b65ee7afec6ac06a144f2d6134f08eeec185f1a890fe34\
+            e68f0e377b7d0312883c048d9b8a1d6ecc3b541cb4987c26f45e0c\
+            82691ea299b5e6889bbfe589153016d8131717ba26f07c3c14ffbe\
+            f1f3eff9752e5b6183f43871a78219a75e7000fbac6a7072e2b83c\
+            790a3a5aecd9d14be79f9fd4fb180960a3772e08680495",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
 
-        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("3eebe6721b2ec746629856dc2dd3f03a830dabfefd7e2d1e72aaf2127d6ad17c988b5762f32e6edf61972378a4106dc4b63fa108ad03b793eedf4588f34c4df2a95b30995a464cb3ee31d6dca30adbfc90ffdf5414d7893082c55b269d9ec9cd6d2a715b9c4fad4eb70ed56f878b55a17b5994ef0de5b338675aad35354195cd")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "ca1b56861482b16eae0f4a26212112362fcc2d76dcc80c93\
+            c4182ed66c5113fe41733ed68be2942a3487394317f3379856f482\
+            2a611735e50528a60e7ade8ec8c71670fec6661e2c59a09ed36386\
+            513221688b35dc47e3c3111ee8c67ff49579089d661caa29db1ef1\
+            0eb6eace575bf3dc9806e7c4016bd50f3c0e2a6481ee6d",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
 
-        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let len_in_bytes = 0x80;
-        let uniform_bytes =
-            hex::decode("858cb4a6a5668a97d0f7039b5d6d574dde18dd2323cf6b203945c66df86477d1f747b46401903b3fa66d1276108ea7187b4411b7499acf4600080ce34ff6d21555c2af16f091adf8b285c8439f2e47fa0553c3a6ef5a4227a13f34406241b7d7fd8853a080bad25ec4804cdfe4fda500e1c872e71b8c61a8e160691894b96058")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "9d763a5ce58f65c91531b4100c7266d479a5d9777ba76169\
+            3d052acd37d149e7ac91c796a10b919cd74a591a1e38719fb91b72\
+            03e2af31eac3bff7ead2c195af7d88b8bc0a8adf3d1e90ab9bed6d\
+            dc2b7f655dd86c730bdeaea884e73741097142c92f0e3fc1811b69\
+            9ba593c7fbd81da288a29d423df831652e3a01a9374999",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
         );
     }
 
-    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-11#appendix-K.4>
+    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.5>
     #[test]
-    fn expand_message_xof_works_for_draft11_testvectors_shake256() {
-        let dst = b"QUUX-V01-CS02-with-expander";
+    fn expand_message_xof_works_for_draft12_testvectors_shake128_long_dst() {
+        let dst = b"QUUX-V01-CS02-with-expander-SHAKE128-long-DST-11111111\
+            111111111111111111111111111111111111111111111111111111\
+            111111111111111111111111111111111111111111111111111111\
+            111111111111111111111111111111111111111111111111111111\
+            1111111111111111111111111111111111111111";
 
         let msg = b"";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("58e90433d81860c47d350b0bb6fb94f98f6b0f9657efd04d410ae743260c096d")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "827c6216330a122352312bccc0c8d6e7a146c5257a776dbd\
+            9ad9d75cd880fc53",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abc";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "690c8d82c7213b4282c6cb41c00e31ea1d3e2005f93ad19b\
+            bf6da40f15790c5c",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abcdef0123456789";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "979e3a15064afbbcf99f62cc09fa9c85028afcf3f825eb07\
+            11894dcfc2f57057",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "c5a9220962d9edc212c063f4f65b609755a1ed96e62f9db5\
+            d1fd6adb5a8dc52b",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "f7b96a5901af5d78ce1d071d9c383cac66a1dfadb508300e\
+            c6aeaea0d62d5d62",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "3890dbab00a2830be398524b71c2713bbef5f4884ac2e6f0\
+            70b092effdb19208c7df943dc5dcbaee3094a78c267ef276632ee2\
+            c8ea0c05363c94b6348500fae4208345dd3475fe0c834c2beac7fa\
+            7bc181692fb728c0a53d809fc8111495222ce0f38468b11becb15b\
+            32060218e285c57a60162c2c8bb5b6bded13973cd41819",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abc";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "41b7ffa7a301b5c1441495ebb9774e2a53dbbf4e54b9a1af\
+            6a20fd41eafd69ef7b9418599c5545b1ee422f363642b01d4a5344\
+            9313f68da3e49dddb9cd25b97465170537d45dcbdf92391b5bdff3\
+            44db4bd06311a05bca7dcd360b6caec849c299133e5c9194f4e15e\
+            3e23cfaab4003fab776f6ac0bfae9144c6e2e1c62e7d57",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"abcdef0123456789";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "55317e4a21318472cd2290c3082957e1242241d9e0d04f47\
+            026f03401643131401071f01aa03038b2783e795bdfa8a3541c194\
+            ad5de7cb9c225133e24af6c86e748deb52e560569bd54ef4dac034\
+            65111a3a44b0ea490fb36777ff8ea9f1a8a3e8e0de3cf0880b4b2f\
+            8dd37d3a85a8b82375aee4fa0e909f9763319b55778e71",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
+            qqqqqqqqqqqqqqqqqqqqqqqqq";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "19fdd2639f082e31c77717ac9bb032a22ff0958382b2dbb3\
+            9020cdc78f0da43305414806abf9a561cb2d0067eb2f7bc544482f\
+            75623438ed4b4e39dd9e6e2909dd858bd8f1d57cd0fce2d3150d90\
+            aa67b4498bdf2df98c0100dd1a173436ba5d0df6be1defb0b2ce55\
+            ccd2f4fc05eb7cb2c019c35d5398b85adc676da4238bc7",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+
+        let msg = b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let len_in_bytes = 0x80;
+        let uniform_bytes = hex::decode(
+            "945373f0b3431a103333ba6a0a34f1efab2702efde41754c\
+            4cb1d5216d5b0a92a67458d968562bde7fa6310a83f53dda138368\
+            0a276a283438d58ceebfa7ab7ba72499d4a3eddc860595f63c93b1\
+            c5e823ea41fc490d938398a26db28f61857698553e93f0574eb8c5\
+            017bfed6249491f9976aaa8d23d9485339cc85ca329308",
+        )
+        .unwrap();
+        assert_eq!(
+            ExpandMsgXof::<Shake128>::init_expand(msg, dst, len_in_bytes).into_vec(),
+            uniform_bytes
+        );
+    }
+
+    /// From <https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-12#appendix-K.6>
+    #[test]
+    fn expand_message_xof_works_for_draft12_testvectors_shake256() {
+        let dst = b"QUUX-V01-CS02-with-expander-SHAKE256";
+
+        let msg = b"";
+        let len_in_bytes = 0x20;
+        let uniform_bytes = hex::decode(
+            "2ffc05c48ed32b95d72e807f6eab9f7530dd1c2f013914c8\
+            fed38c5ccc15ad76",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -666,9 +1136,11 @@ mod tests {
 
         let msg = b"abc";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("c7f5e3c044790033707e24f21d971aaa03a760dfda6215bf0c8634da9012c8f8")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "b39e493867e2767216792abce1f2676c197c0692aed06156\
+            0ead251821808e07",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -676,9 +1148,11 @@ mod tests {
 
         let msg = b"abcdef0123456789";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("f46930964d5d5006ef992f5878d7c255c9a92aed1032c9b9d4743ec1470a91e8")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "245389cf44a13f0e70af8665fe5337ec2dcd138890bb7901\
+            c4ad9cfceb054b65",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -688,9 +1162,11 @@ mod tests {
             qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\
             qqqqqqqqqqqqqqqqqqqqqqqqq";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("885baaf4841ad28aa853022289cb4841cc6c1bf200c579e8aebb8d005a8ff37f")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "719b3911821e6428a5ed9b8e600f2866bcf23c8f0515e52d\
+            6c6c019a03f16f0e",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -707,9 +1183,11 @@ mod tests {
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let len_in_bytes = 0x20;
-        let uniform_bytes =
-            hex::decode("4a9884b31a64772244df05622222db6cb9942034370d2400e39bb853cca727f7")
-                .unwrap();
+        let uniform_bytes = hex::decode(
+            "9181ead5220b1963f1b5951f35547a5ea86a820562287d6c\
+            a4723633d17ccbbc",
+        )
+        .unwrap();
         assert_eq!(
             ExpandMsgXof::<Shake256>::init_expand(msg, dst, len_in_bytes).into_vec(),
             uniform_bytes
@@ -718,11 +1196,11 @@ mod tests {
         let msg = b"";
         let len_in_bytes = 0x80;
         let uniform_bytes = hex::decode(
-            "4cbc65744a4a26c059472822a4647887abb4a3220d5c1e11\
-            55c4180a04c69541d437b77676fc5b6450faa5cb906d88a8fa7e1c\
-            6807d0a66f0092cc022812368e75ba41dcb4daab00a17e752d485f\
-            5e21f835ac36f05b9d0217c79376045e1360faa4652db9d7752af1\
-            ffb76ae14cf6aabd7b08b19032d213415d2cef8cd6b62f",
+            "7a1361d2d7d82d79e035b8880c5a3c86c5afa719478c007d\
+            96e6c88737a3f631dd74a2c88df79a4cb5e5d9f7504957c70d669e\
+            c6bfedc31e01e2bacc4ff3fdf9b6a00b17cc18d9d72ace7d6b81c2\
+            e481b4f73f34f9a7505dccbe8f5485f3d20c5409b0310093d5d649\
+            2dea4e18aa6979c23c8ea5de01582e9689612afbb353df",
         )
         .unwrap();
         assert_eq!(
@@ -733,11 +1211,11 @@ mod tests {
         let msg = b"abc";
         let len_in_bytes = 0x80;
         let uniform_bytes = hex::decode(
-            "c5f366dc668697014a0a90a40ae27c19edcb8500f6ad5d42\
-            34fbf4204f64df524a44adaecb42102fffeb7686949aa6785142b2\
-            510a419dd29dadf1f2b455688c043f6bc2fd76b101dd8e41cca404\
-            2514a6b15d137d958735961e3c32a49e0640ad564d533d20adc203\
-            c5befdb1186ca18646b729a5cb4531922d24a17b4389ea",
+            "a54303e6b172909783353ab05ef08dd435a558c3197db0c1\
+            32134649708e0b9b4e34fb99b92a9e9e28fc1f1d8860d85897a8e0\
+            21e6382f3eea10577f968ff6df6c45fe624ce65ca25932f679a42a\
+            404bc3681efe03fcd45ef73bb3a8f79ba784f80f55ea8a3c367408\
+            f30381299617f50c8cf8fbb21d0f1e1d70b0131a7b6fbe",
         )
         .unwrap();
         assert_eq!(
@@ -748,11 +1226,11 @@ mod tests {
         let msg = b"abcdef0123456789";
         let len_in_bytes = 0x80;
         let uniform_bytes = hex::decode(
-            "34dcc64cee945b94c5e29a9aa6b859b8a9705fe020bf7443\
-            eaab4c8269e739904e2703cef64e1823b5c848570db97b28da7869\
-            f52c24573d8f759b7181726e186dcff940eea5f70a11ebd14b4c90\
-            c3b17805ce91dc3157ce635e9d11fe56d86dfa76a79e84c11e2536\
-            53350d2f954922077f2ea6a17104dd0fd963d7fe4568d3",
+            "e42e4d9538a189316e3154b821c1bafb390f78b2f010ea40\
+            4e6ac063deb8c0852fcd412e098e231e43427bd2be1330bb47b403\
+            9ad57b30ae1fc94e34993b162ff4d695e42d59d9777ea18d3848d9\
+            d336c25d2acb93adcad009bcfb9cde12286df267ada283063de0bb\
+            1505565b2eb6c90e31c48798ecdc71a71756a9110ff373",
         )
         .unwrap();
         assert_eq!(
@@ -765,11 +1243,11 @@ mod tests {
             qqqqqqqqqqqqqqqqqqqqqqqqq";
         let len_in_bytes = 0x80;
         let uniform_bytes = hex::decode(
-            "b0adc10a4326ae3ddf11c42afb89058625f8812c76b2a0fb\
-            17570f7a2acb030e8dd20036d1326984fd0d973197d80fbf461fe1\
-            8ef394b9a22e609e61d710df43476ddf3a8ca4d32b737bc265d14a\
-            204f32173e447db74bc68938b6a6a08e3e9a31968e5d05a0ca213c\
-            977e94cffc9a535b5c5198a6c5892bbce1a35ecc7ab2bd",
+            "4ac054dda0a38a65d0ecf7afd3c2812300027c8789655e47\
+            aecf1ecc1a2426b17444c7482c99e5907afd9c25b991990490bb9c\
+            686f43e79b4471a23a703d4b02f23c669737a886a7ec28bddb92c3\
+            a98de63ebf878aa363a501a60055c048bea11840c4717beae7eee2\
+            8c3cfa42857b3d130188571943a7bd747de831bd6444e0",
         )
         .unwrap();
         assert_eq!(
@@ -789,11 +1267,11 @@ mod tests {
             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let len_in_bytes = 0x80;
         let uniform_bytes = hex::decode(
-            "50a0cb335f3102a15f3dfed981b0a5fecb3136112532e129\
-            d39369a2a92c32a9b0a0181af9839039c0e98a3b66a0d209fa0191\
-            34991055284c3f475c9f7c91169dea57aad442f0c98418d36e50fa\
-            d68e8863109dac6d8cfc6c5fa63e8f1c0468af9980066e87b62caa\
-            87f4b3feef0dba8ef894f2957105d111439597d3265b1f",
+            "09afc76d51c2cccbc129c2315df66c2be7295a231203b8ab\
+            2dd7f95c2772c68e500bc72e20c602abc9964663b7a03a389be128\
+            c56971ce81001a0b875e7fd17822db9d69792ddf6a23a151bf4700\
+            79c518279aef3e75611f8f828994a9988f4a8a256ddb8bae161e65\
+            8d5a2a09bcfe839c6396dc06ee5c8ff3c22d3b1f9deb7e",
         )
         .unwrap();
         assert_eq!(

--- a/src/hash_to_curve/map_g1.rs
+++ b/src/hash_to_curve/map_g1.rs
@@ -538,9 +538,9 @@ impl Sgn0 for Fp {
 
 /// Maps an element of [`Fp`] to a point on iso-G1.
 ///
-/// Implements [section 6.6.2 of `draft-irtf-cfrg-hash-to-curve-11`][sswu].
+/// Implements [section 6.6.2 of `draft-irtf-cfrg-hash-to-curve-12`][sswu].
 ///
-/// [sswu]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-6.6.2
+/// [sswu]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-6.6.2
 fn map_to_curve_simple_swu(u: &Fp) -> G1Projective {
     let usq = u.square();
     let xi_usq = SSWU_XI * usq;

--- a/src/hash_to_curve/mod.rs
+++ b/src/hash_to_curve/mod.rs
@@ -20,7 +20,7 @@ use crate::generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 /// Enables a byte string to be hashed into one or more field elements for a given curve.
 ///
-/// Implements [section 5 of `draft-irtf-cfrg-hash-to-2`][hash_to_field].
+/// Implements [section 5 of `draft-irtf-cfrg-hash-to-curve-12`][hash_to_field].
 ///
 /// [hash_to_field]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-5
 pub trait HashToField: Sized {

--- a/src/hash_to_curve/mod.rs
+++ b/src/hash_to_curve/mod.rs
@@ -20,9 +20,9 @@ use crate::generic_array::{typenum::Unsigned, ArrayLength, GenericArray};
 
 /// Enables a byte string to be hashed into one or more field elements for a given curve.
 ///
-/// Implements [section 5 of `draft-irtf-cfrg-hash-to-curve-11`][hash_to_field].
+/// Implements [section 5 of `draft-irtf-cfrg-hash-to-2`][hash_to_field].
 ///
-/// [hash_to_field]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-5
+/// [hash_to_field]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-5
 pub trait HashToField: Sized {
     /// The length of the data used to produce an individual field element.
     ///
@@ -38,9 +38,9 @@ pub trait HashToField: Sized {
     /// Hashes a byte string of arbitrary length into one or more elements of `Self`,
     /// using [`ExpandMessage`] variant `X`.
     ///
-    /// Implements [section 5.3 of `draft-irtf-cfrg-hash-to-curve-11`][hash_to_field].
+    /// Implements [section 5.3 of `draft-irtf-cfrg-hash-to-curve-12`][hash_to_field].
     ///
-    /// [hash_to_field]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-5.3
+    /// [hash_to_field]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-5.3
     fn hash_to_field<X: ExpandMessage>(message: &[u8], dst: &[u8], output: &mut [Self]) {
         let len_per_elm = Self::InputLength::to_usize();
         let len_in_bytes = output.len() * len_per_elm;
@@ -85,10 +85,10 @@ pub trait HashToCurve<X: ExpandMessage>: MapToCurve + for<'a> Add<&'a Self, Outp
     /// The distribution of its output is not uniformly random in `Self`: the set of
     /// possible outputs of this function is only a fraction of the points in `Self`, and
     /// some elements of this set are more likely to be output than others. See
-    /// [section 10.1 of `draft-irtf-cfrg-hash-to-curve-11`][encode_to_curve-distribution]
+    /// [section 10.1 of `draft-irtf-cfrg-hash-to-curve-12`][encode_to_curve-distribution]
     /// for a more precise definition of `encode_to_curve`'s output distribution.
     ///
-    /// [encode_to_curve-distribution]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-10.1
+    /// [encode_to_curve-distribution]: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-12#section-10.1
     fn encode_to_curve(message: impl AsRef<[u8]>, dst: &[u8]) -> Self {
         let mut u = [Self::Field::default(); 1];
         Self::Field::hash_to_field::<X>(message.as_ref(), dst, &mut u);


### PR DESCRIPTION
No code changes apart from unit tests, plus some updated links. The draft now includes tests with a long DST so a couple custom unit tests are removed.