### PR TITLE
add fast subgroup check for is_torsion_free

### DIFF
--- a/src/g1.rs
+++ b/src/g1.rs
@@ -406,7 +406,7 @@ impl G1Affine {
 
         let minus_x_squared_times_p = G1Projective::from(self).mul_by_x().mul_by_x().neg();
         let endomorphism_p = endomorphism(self);
-        G1Affine::from(minus_x_squared_times_p).ct_eq(&endomorphism_p)
+        minus_x_squared_times_p.ct_eq(&G1Projective::from(endomorphism_p))
     }
 
     /// Returns true if this point is on the curve. This should always return

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -400,9 +400,8 @@ impl G1Affine {
     /// unless an "unchecked" API was used.
     pub fn is_torsion_free(&self) -> Choice {
         // Algorithm from Section 6 of https://eprint.iacr.org/2021/1130
-        // Updated proof of correctness in https://eprint.iacr.org/2022/352
         //
-        // Check that endomorphism_p(P) == -[X^2]P
+        // Check that endomorphism_p(P) == -[x^2] P
 
         let minus_x_squared_times_p = G1Projective::from(self).mul_by_x().mul_by_x().neg();
         let endomorphism_p = endomorphism(self);

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -399,19 +399,12 @@ impl G1Affine {
     /// exists within the $q$-order subgroup $\mathbb{G}_1$. This should always return true
     /// unless an "unchecked" API was used.
     pub fn is_torsion_free(&self) -> Choice {
-        // Algorithm from Section 6 of https://eprint.iacr.org/2021/1130.
+        // Algorithm from Section 6 of https://eprint.iacr.org/2021/1130
+        // Updated proof of correctness in https://eprint.iacr.org/2022/352
         //
         // Check that endomorphism_p(P) == -[X^2]P
 
-        // An early-out optimization described in Section 6.
-        // If uP == P but P != point of infinity, then the point is not in the right
-        // subgroup.
-        let x_times_p = G1Projective::from(self).mul_by_x().neg();
-        if G1Affine::from(x_times_p).eq(self) && !bool::from(self.infinity) {
-            return Choice::from(0u8);
-        }
-
-        let minus_x_squared_times_p = x_times_p.mul_by_x();
+        let minus_x_squared_times_p = G1Projective::from(self).mul_by_x().mul_by_x().neg();
         let endomorphism_p = endomorphism(self);
         G1Affine::from(minus_x_squared_times_p).ct_eq(&endomorphism_p)
     }

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -418,7 +418,7 @@ impl G1Affine {
 }
 
 /// A nontrivial third root of unity in Fp
-pub const BETA: Fp = Fp([
+pub const BETA: Fp = Fp::from_raw_unchecked([
     0x30f1_361b_798a_64e8,
     0xf3b8_ddab_7ece_5a2a,
     0x16a8_ca3a_c615_77f7,
@@ -427,7 +427,7 @@ pub const BETA: Fp = Fp([
     0x051b_a4ab_241b_6160,
 ]);
 
-pub fn endomorphism(p: &G1Affine) -> G1Affine {
+fn endomorphism(p: &G1Affine) -> G1Affine {
     // Endomorphism of the points on the curve.
     // endomorphism_p(x,y) = (BETA * x, y)
     // where BETA is a non-trivial cubic root of unity in Fq.
@@ -1085,6 +1085,7 @@ fn test_beta() {
         .unwrap()
     );
     assert_ne!(BETA, Fp::one());
+    assert_ne!(BETA * BETA, Fp::one());
     assert_eq!(BETA * BETA * BETA, Fp::one());
 }
 #[test]

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -399,15 +399,21 @@ impl G1Affine {
     /// exists within the $q$-order subgroup $\mathbb{G}_1$. This should always return true
     /// unless an "unchecked" API was used.
     pub fn is_torsion_free(&self) -> Choice {
-        const FQ_MODULUS_BYTES: [u8; 32] = [
-            1, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
-            216, 57, 51, 72, 125, 157, 41, 83, 167, 237, 115,
-        ];
+        // Algorithm from Section 6 of https://eprint.iacr.org/2021/1130.
+        //
+        // Check that endomorphism_p(P) == -[X^2]P
 
-        // Clear the r-torsion from the point and check if it is the identity
-        G1Projective::from(*self)
-            .multiply(&FQ_MODULUS_BYTES)
-            .is_identity()
+        // An early-out optimization described in Section 6.
+        // If uP == P but P != point of infinity, then the point is not in the right
+        // subgroup.
+        let x_times_p = G1Projective::from(self).mul_by_x().neg();
+        if G1Affine::from(x_times_p).eq(self) && !bool::from(self.infinity) {
+            return Choice::from(0u8);
+        }
+
+        let minus_x_squared_times_p = x_times_p.mul_by_x();
+        let endomorphism_p = endomorphism(self);
+        G1Affine::from(minus_x_squared_times_p).ct_eq(&endomorphism_p)
     }
 
     /// Returns true if this point is on the curve. This should always return
@@ -416,6 +422,25 @@ impl G1Affine {
         // y^2 - x^3 ?= 4
         (self.y.square() - (self.x.square() * self.x)).ct_eq(&B) | self.infinity
     }
+}
+
+/// A nontrivial third root of unity in Fp
+pub const BETA: Fp = Fp([
+    0x30f1_361b_798a_64e8,
+    0xf3b8_ddab_7ece_5a2a,
+    0x16a8_ca3a_c615_77f7,
+    0xc26a_2ff8_74fd_029b,
+    0x3636_b766_6070_1c6e,
+    0x051b_a4ab_241b_6160,
+]);
+
+pub fn endomorphism(p: &G1Affine) -> G1Affine {
+    // Endomorphism of the points on the curve.
+    // endomorphism_p(x,y) = (BETA * x, y)
+    // where BETA is a non-trivial cubic root of unity in Fq.
+    let mut res = p.clone();
+    res.x *= BETA;
+    res
 }
 
 /// This is an element of $\mathbb{G}_1$ represented in the projective coordinate space.
@@ -1054,6 +1079,21 @@ impl UncompressedEncoding for G1Affine {
     }
 }
 
+#[test]
+fn test_beta() {
+    assert_eq!(
+        BETA,
+        Fp::from_bytes(&[
+            0x00u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5f, 0x19, 0x67, 0x2f, 0xdf, 0x76,
+            0xce, 0x51, 0xba, 0x69, 0xc6, 0x07, 0x6a, 0x0f, 0x77, 0xea, 0xdd, 0xb3, 0xa9, 0x3b,
+            0xe6, 0xf8, 0x96, 0x88, 0xde, 0x17, 0xd8, 0x13, 0x62, 0x0a, 0x00, 0x02, 0x2e, 0x01,
+            0xff, 0xff, 0xff, 0xfe, 0xff, 0xfe
+        ])
+        .unwrap()
+    );
+    assert_ne!(BETA, Fp::one());
+    assert_eq!(BETA * BETA * BETA, Fp::one());
+}
 #[test]
 fn test_is_on_curve() {
     assert!(bool::from(G1Affine::identity().is_on_curve()));

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -400,6 +400,7 @@ impl G1Affine {
     /// unless an "unchecked" API was used.
     pub fn is_torsion_free(&self) -> Choice {
         // Algorithm from Section 6 of https://eprint.iacr.org/2021/1130
+        // Updated proof of correctness in https://eprint.iacr.org/2022/352
         //
         // Check that endomorphism_p(P) == -[x^2] P
 

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -473,10 +473,12 @@ impl G2Affine {
     /// exists within the $q$-order subgroup $\mathbb{G}_2$. This should always return true
     /// unless an "unchecked" API was used.
     pub fn is_torsion_free(&self) -> Choice {
+        // Algorithm from Section 4 of https://eprint.iacr.org/2021/1130
+        // Updated proof of correctness in https://eprint.iacr.org/2022/352
+        //
+        // Check that psi(P) == [x] P
         let p = G2Projective::from(self);
-        let x_times_p = p.mul_by_x();
-
-        x_times_p.ct_eq(&p.psi())
+        p.psi().ct_eq(&p.mul_by_x())
     }
 
     /// Returns true if this point is on the curve. This should always return

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -473,15 +473,10 @@ impl G2Affine {
     /// exists within the $q$-order subgroup $\mathbb{G}_2$. This should always return true
     /// unless an "unchecked" API was used.
     pub fn is_torsion_free(&self) -> Choice {
-        const FQ_MODULUS_BYTES: [u8; 32] = [
-            1, 0, 0, 0, 255, 255, 255, 255, 254, 91, 254, 255, 2, 164, 189, 83, 5, 216, 161, 9, 8,
-            216, 57, 51, 72, 125, 157, 41, 83, 167, 237, 115,
-        ];
+        let p = G2Projective::from(self);
+        let x_times_p = p.mul_by_x();
 
-        // Clear the r-torsion from the point and check if it is the identity
-        G2Projective::from(*self)
-            .multiply(&FQ_MODULUS_BYTES)
-            .is_identity()
+        x_times_p.ct_eq(&p.psi())
     }
 
     /// Returns true if this point is on the curve. This should always return

--- a/src/notes/design.rs
+++ b/src/notes/design.rs
@@ -60,3 +60,28 @@
 //! 			print("g2 generator: {}".format(p))
 //! 			break
 //! ```
+//!
+//! ## Nontrivial third root of unity
+//!
+//! To use the fast subgroup check algorithm for $\mathbb{G_1}$ from  https://eprint.iacr.org/2019/814.pdf and
+//! https://eprint.iacr.org/2021/1130, it is necessary to find a nontrivial cube root of
+//! unity β in Fp to define the endomorphism:
+//!        (x, y) -> (βx, y)
+//! which is equivalent to
+//!        P -> λP
+//! where λ, a nontrivial cube root of unity in Fr, satisfies λ^2 + λ +1 = 0 (mod r).
+//!
+//! β can be derived using the following sage script:
+//!
+//! ```text
+//! p = 4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787
+//! Fp = GF(p)
+//! Fpx.<x> = Fp[]
+//! β = 793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350
+//! assert β ==(Fp.multiplicative_generator() ** ((p-1)/3))
+//! R = 1 << 384
+//! tmp = ZZ(Fp(β*R))
+//! while tmp > 0:
+//!     print("0x{:_x}, ".format(tmp % (1<<64)))
+//!     tmp >>= 64
+//! ```

--- a/src/notes/design.rs
+++ b/src/notes/design.rs
@@ -63,25 +63,45 @@
 //!
 //! ## Nontrivial third root of unity
 //!
-//! To use the fast subgroup check algorithm for $\mathbb{G_1}$ from  https://eprint.iacr.org/2019/814.pdf and
+//! To use the fast subgroup check algorithm for $\mathbb{G_1}$ from https://eprint.iacr.org/2019/814.pdf and
 //! https://eprint.iacr.org/2021/1130, it is necessary to find a nontrivial cube root of
 //! unity β in Fp to define the endomorphism:
-//!        (x, y) -> (βx, y)
+//!        $$(x, y) \rightarrow (\beta x, y)$$
 //! which is equivalent to
-//!        P -> λP
-//! where λ, a nontrivial cube root of unity in Fr, satisfies λ^2 + λ +1 = 0 (mod r).
+//!        $$P \rightarrow \lambda P$$
+//! where $\lambda$, a nontrivial cube root of unity in Fr, satisfies $\lambda^2 + \lambda +1 = 0 \pmod{r}.
 //!
-//! β can be derived using the following sage script:
+//! $$\beta = 793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350$$
+//! can be derived using the following sage commands after running the above sage script:
 //!
 //! ```text
-//! p = 4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559787
-//! Fp = GF(p)
-//! Fpx.<x> = Fp[]
-//! β = 793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350
-//! assert β ==(Fp.multiplicative_generator() ** ((p-1)/3))
-//! R = 1 << 384
-//! tmp = ZZ(Fp(β*R))
-//! while tmp > 0:
-//!     print("0x{:_x}, ".format(tmp % (1<<64)))
-//!     tmp >>= 64
+//! def print_fq(a):
+//!     R = 1 << 384
+//!     tmp = ZZ(Fq(a*R))
+//!     while tmp > 0:
+//!         print("0x{:_x}, ".format(tmp % (1 << 64)))
+//!         tmp >>= 64
+//! β = (Fq.multiplicative_generator() ** ((q-1)/3))
+//! print_fq(β)
+//! ```
+//!
+//! ## Psi
+//!
+//! To use the fast subgroup check algorithm for $\mathbb{G_2}$ from https://eprint.iacr.org/2019/814.pdf and
+//! https://eprint.iacr.org/2021/1130, it is necessary to find the endomorphism:
+//!
+//! $$(x, y, z) \rightarrow (x^q \psi_x, y^q \psi_y, z^q)$$
+//!
+//! where:
+//!
+//! 1. $\psi_x = 1 / ((i+1) ^ ((q-1)/3)) \in \mathbb{F}_{q^2}$, and
+//! 2. $\psi_y = 1 / ((i+1) ^ ((q-1)/2)) \in \mathbb{F}_{q^2}$
+//!
+//! can be derived using the following sage commands after running the above script and commands:
+//! ```text
+//! psi_x = (1/((i+1)**((q-1)/3)))
+//! psi_y = (1/((i+1)**((q-1)/2)))
+//! print_fq(psi_x.polynomial().coefficients()[0])
+//! print_fq(psi_y.polynomial().coefficients()[0])
+//! print_fq(psi_y.polynomial().coefficients()[1])
 //! ```

--- a/src/notes/design.rs
+++ b/src/notes/design.rs
@@ -75,6 +75,7 @@
 //! can be derived using the following sage commands after running the above sage script:
 //!
 //! ```text
+//! # Prints the given field element in Montgomery form.
 //! def print_fq(a):
 //!     R = 1 << 384
 //!     tmp = ZZ(Fq(a*R))


### PR DESCRIPTION
Similar to #80, this uses Scott's method from https://eprint.iacr.org/2021/1130 as implemented by @simonmasson for arkworks (https://github.com/arkworks-rs/curves/pull/74)