### PR TITLE
Add feature requirements to relic test

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -76,6 +76,7 @@ fn g2_compressed_valid_test_vectors() {
 }
 
 #[test]
+#[cfg(all(feature = "alloc", feature = "pairing"))]
 fn test_pairing_result_against_relic() {
     /*
     Sent to me from Diego Aranha (author of RELIC library):


### PR DESCRIPTION
Fixes `cargo test --no-default-features --features groups`