### PR TITLE
Add commutativy to scalar multiplications with G1 and G2 subgroups

### DIFF
--- a/src/g1.rs
+++ b/src/g1.rs
@@ -561,11 +561,29 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a G1Projective {
     }
 }
 
+impl<'a, 'b> Mul<&'b G1Projective> for &'a Scalar {
+    type Output = G1Projective;
+
+    #[inline]
+    fn mul(self, rhs: &'b G1Projective) -> Self::Output {
+        rhs * self
+    }
+}
+
 impl<'a, 'b> Mul<&'b Scalar> for &'a G1Affine {
     type Output = G1Projective;
 
     fn mul(self, other: &'b Scalar) -> Self::Output {
         G1Projective::from(self).multiply(&other.to_bytes())
+    }
+}
+
+impl<'a, 'b> Mul<&'b G1Affine> for &'a Scalar {
+    type Output = G1Projective;
+
+    #[inline]
+    fn mul(self, rhs: &'b G1Affine) -> Self::Output {
+        rhs * self
     }
 }
 
@@ -1726,4 +1744,20 @@ fn test_zeroize() {
     let mut a = UncompressedEncoding::to_uncompressed(&G1Affine::generator());
     a.zeroize();
     assert_eq!(&a, &G1Uncompressed::default());
+}
+
+#[test]
+fn test_commutative_scalar_subgroup_multiplication() {
+    let a = Scalar::from_raw([
+        0x1fff_3231_233f_fffd,
+        0x4884_b7fa_0003_4802,
+        0x998c_4fef_ecbc_4ff3,
+        0x1824_b159_acc5_0562,
+    ]);
+
+    let g1_a = G1Affine::generator();
+    let g1_p = G1Projective::generator();
+
+    assert_eq!(&g1_a * &a, &a * &g1_a);
+    assert_eq!(&g1_p * &a, &a * &g1_p);
 }

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -614,11 +614,29 @@ impl<'a, 'b> Mul<&'b Scalar> for &'a G2Projective {
     }
 }
 
+impl<'a, 'b> Mul<&'b G2Projective> for &'a Scalar {
+    type Output = G2Projective;
+
+    #[inline]
+    fn mul(self, rhs: &'b G2Projective) -> Self::Output {
+        rhs * self
+    }
+}
+
 impl<'a, 'b> Mul<&'b Scalar> for &'a G2Affine {
     type Output = G2Projective;
 
     fn mul(self, other: &'b Scalar) -> Self::Output {
         G2Projective::from(self).multiply(&other.to_bytes())
+    }
+}
+
+impl<'a, 'b> Mul<&'b G2Affine> for &'a Scalar {
+    type Output = G2Projective;
+
+    #[inline]
+    fn mul(self, rhs: &'b G2Affine) -> Self::Output {
+        rhs * self
     }
 }
 
@@ -2129,4 +2147,20 @@ fn test_zeroize() {
     let mut a = UncompressedEncoding::to_uncompressed(&G2Affine::generator());
     a.zeroize();
     assert_eq!(&a, &G2Uncompressed::default());
+}
+
+#[test]
+fn test_commutative_scalar_subgroup_multiplication() {
+    let a = Scalar::from_raw([
+        0x1fff_3231_233f_fffd,
+        0x4884_b7fa_0003_4802,
+        0x998c_4fef_ecbc_4ff3,
+        0x1824_b159_acc5_0562,
+    ]);
+
+    let g2_a = G2Affine::generator();
+    let g2_p = G2Projective::generator();
+
+    assert_eq!(&g2_a * &a, &a * &g2_a);
+    assert_eq!(&g2_p * &a, &a * &g2_p);
 }


### PR DESCRIPTION
## Motivation

Natural Number multiplications with a member of a group (representing repeated addition of a group member) are naturally commutative. Prior to this PR, this PR was effectively non-commutative. This PR adds a few simple add ons to the Mul trait to add commutativity.

## Changelog

* Added `Mul` traits from `G1Affine` `G2Affine` `G1Projective` and `G2Projective` for Scalar types
* Added unit tests to enforce equality of commutative scalar multiplications