### PR TITLE
bump msrv to `1.64.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/zkcrypto/bls12_381"
 license = "MIT/Apache-2.0"
 name = "bls12_381"
 repository = "https://github.com/zkcrypto/bls12_381"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.8.1
+## Changed
+- MSRV bumped to `1.64.0`
+
 # 0.8.0
 ## Changed
 - Bumped dependencies to `ff 0.13`, `group 0.13`, `pairing 0.23`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.0"
+channel = "1.64.0"
 components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
A bump of MSRV is done to fix:

```shell
error: package `rayon-core v1.12.0` cannot be built because it requires rustc 1.63 or newer, while the currently active rustc version is 1.56.0
```

`rustc 1.63` has a problem with compilation that's why this is directly bumped to `1.64.0`