### PR TITLE
Implement conversion traits for G{1,2}{Compressed,Uncompressed}

### DIFF
--- a/src/g1.rs
+++ b/src/g1.rs
@@ -884,6 +884,12 @@ impl AsMut<[u8]> for G1Compressed {
     }
 }
 
+impl From<G1Compressed> for [u8; 48] {
+    fn from(value: G1Compressed) -> Self {
+        value.0
+    }
+}
+
 impl ConstantTimeEq for G1Compressed {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
@@ -925,6 +931,12 @@ impl AsRef<[u8]> for G1Uncompressed {
 impl AsMut<[u8]> for G1Uncompressed {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
+    }
+}
+
+impl From<G1Uncompressed> for [u8; 96] {
+    fn from(value: G1Uncompressed) -> Self {
+        value.0
     }
 }
 

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -1029,6 +1029,12 @@ impl AsMut<[u8]> for G2Compressed {
     }
 }
 
+impl From<G2Compressed> for [u8; 96] {
+    fn from(value: G2Compressed) -> Self {
+        value.0
+    }
+}
+
 impl ConstantTimeEq for G2Compressed {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
@@ -1070,6 +1076,12 @@ impl AsRef<[u8]> for G2Uncompressed {
 impl AsMut<[u8]> for G2Uncompressed {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0
+    }
+}
+
+impl From<G2Uncompressed> for [u8; 192] {
+    fn from(value: G2Uncompressed) -> Self {
+        value.0
     }
 }
 


### PR DESCRIPTION
This makes it possible to retrieve the inner bytes without converting to/from a slice.

The copied slice will clearly lose the protection of zeroize (if the feature is enabled), but, IMO, that's a decision the user should be free to make.