### PR TITLE
Remove unnecessary doubling condition

### DIFF
--- a/src/g1.rs
+++ b/src/g1.rs
@@ -657,13 +657,11 @@ impl G1Projective {
         let x3 = t0 * t1;
         let x3 = x3 + x3;
 
-        let tmp = G1Projective {
+        G1Projective {
             x: x3,
             y: y3,
             z: z3,
-        };
-
-        G1Projective::conditional_select(&tmp, &G1Projective::identity(), self.is_identity())
+        }
     }
 
     /// Adds this point to another point.

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -728,13 +728,11 @@ impl G2Projective {
         let x3 = t0 * t1;
         let x3 = x3 + x3;
 
-        let tmp = G2Projective {
+        G2Projective {
             x: x3,
             y: y3,
             z: z3,
-        };
-
-        G2Projective::conditional_select(&tmp, &G2Projective::identity(), self.is_identity())
+        }
     }
 
     /// Adds this point to another point.


### PR DESCRIPTION
Hi there
I found unnecessary condition branch.

Projective identity is $(x, y, z) = (0, 1, 0)$ and doubling is as follows.

```rust
let t0 = self.y.square();
let z3 = t0 + t0;
let z3 = z3 + z3;
let z3 = z3 + z3;
let t1 = self.y * self.z;
let t2 = self.z.square();
let t2 = mul_by_3b(t2);
let x3 = t2 * z3;
let y3 = t0 + t2;
let z3 = t1 * z3;
let t1 = t2 + t2;
let t2 = t1 + t2;
let t0 = t0 - t2;
let y3 = t0 * y3;
let y3 = x3 + y3;
let t1 = self.x * self.y;
let x3 = t0 * t1;
let x3 = x3 + x3;

let tmp = G1Projective {
    x: x3,
    y: y3,
    z: z3,
};

G1Projective::conditional_select(&tmp, &G1Projective::identity(), self.is_identity())
```

- Arithmetic Trace

$(x, y, z) = (0, 1, 0)$

t0 = 1 (y^2)
z3 = 2 (t0 + t0)
z3 = 4 (z3 + z3)
t1 = 0 (y * z)
t2 = 0 (z^2)
t2 = 0 (t2 * 12)
x3 = 0 (t2 * z3)
y3 = 1 (t0 + t2)
z3 = 0 (t1 * z3)
t1 = 0 (t2 + t2)
t2 = 0 (t1 + t2)
t0 = 1 (t0 - t2)
y3 = 1 (t0 * y3)
y3 = 1 (x3 + y3)
t1 = 0 (x * y)
x3 = 0 (t0 * t1)
x3 = 0 (x3 + x3)

$(x3, y3, z3) = (0, 1, 0)$

`double` arithmetic covers the identity case.

- Other Concerns

Field `double` is faster than `add`
[`add_mixed` identity condition](https://github.com/zkcrypto/bls12_381/blob/main/src/g1.rs#L751) may not necessary

I would appreciate it if you could confirm.
Thank you.