### PR TITLE
add basic serde support for Scalar, G1, G2 with human readable encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hex = "0.4"
 rand_xorshift = "0.3"
 sha2 = "0.9"
 sha3 = "0.9"
+serde_json = "1.0.114"
 
 [[bench]]
 name = "groups"
@@ -63,6 +64,15 @@ version = "1.4"
 default-features = false
 optional = true
 
+[dependencies.serde]
+version = "1.0.197"
+default-features = false
+optional = true
+
+[dependencies.serdect]
+version = "0.2.0"
+optional = true
+
 [features]
 default = ["groups", "pairings", "alloc", "bits"]
 bits = ["ff/bits"]
@@ -71,3 +81,4 @@ pairings = ["groups", "pairing"]
 alloc = ["group/alloc"]
 experimental = ["digest"]
 nightly = ["subtle/nightly"]
+serde = ["dep:serde", "serdect"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,3 +88,6 @@ pub(crate) use digest::generic_array;
 
 #[cfg(feature = "experimental")]
 pub mod hash_to_curve;
+
+#[cfg(feature = "serde")]
+mod serde;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,124 @@
+use group::Curve;
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::g1::{G1Affine, G1Projective};
+use crate::g2::{G2Affine, G2Projective};
+use crate::scalar::Scalar;
+
+impl Serialize for Scalar {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serdect::array::serialize_hex_lower_or_bin(&self.to_bytes(), s)
+    }
+}
+
+impl<'d> Deserialize<'d> for Scalar {
+    fn deserialize<D: Deserializer<'d>>(d: D) -> Result<Self, D::Error> {
+        let mut byte_array = [0; 32];
+
+        serdect::array::deserialize_hex_or_bin(&mut byte_array, d)?;
+
+        Option::from(Scalar::from_bytes(&byte_array))
+            .ok_or_else(|| D::Error::custom("Could not decode scalar"))
+    }
+}
+
+impl Serialize for G1Affine {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serdect::array::serialize_hex_lower_or_bin(&self.to_compressed(), s)
+    }
+}
+
+impl<'d> Deserialize<'d> for G1Affine {
+    fn deserialize<D: Deserializer<'d>>(d: D) -> Result<Self, D::Error> {
+        let mut byte_array = [0; 48];
+
+        serdect::array::deserialize_hex_or_bin(&mut byte_array, d)?;
+
+        Option::from(G1Affine::from_compressed(&byte_array))
+            .ok_or_else(|| D::Error::custom("Could not decode compressed group element"))
+    }
+}
+
+impl Serialize for G2Affine {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serdect::array::serialize_hex_lower_or_bin(&self.to_compressed(), s)
+    }
+}
+
+impl<'d> Deserialize<'d> for G2Affine {
+    fn deserialize<D: Deserializer<'d>>(d: D) -> Result<Self, D::Error> {
+        let mut byte_array = [0; 96];
+
+        serdect::array::deserialize_hex_or_bin(&mut byte_array, d)?;
+
+        Option::from(G2Affine::from_compressed(&byte_array))
+            .ok_or_else(|| D::Error::custom("Could not decode compressed group element"))
+    }
+}
+
+impl Serialize for G1Projective {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.to_affine().serialize(s)
+    }
+}
+
+impl<'d> Deserialize<'d> for G1Projective {
+    fn deserialize<D: Deserializer<'d>>(d: D) -> Result<Self, D::Error> {
+        Ok(G1Affine::deserialize(d)?.into())
+    }
+}
+
+impl Serialize for G2Projective {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        self.to_affine().serialize(s)
+    }
+}
+
+impl<'d> Deserialize<'d> for G2Projective {
+    fn deserialize<D: Deserializer<'d>>(d: D) -> Result<Self, D::Error> {
+        Ok(G2Affine::deserialize(d)?.into())
+    }
+}
+
+#[test]
+fn serde_json_scalar_roundtrip() {
+    let serialized = serde_json::to_string(&Scalar::zero()).unwrap();
+
+    assert_eq!(
+        serialized,
+        "\"0000000000000000000000000000000000000000000000000000000000000000\""
+    );
+
+    let deserialized: Scalar = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(deserialized, Scalar::zero());
+}
+
+#[test]
+fn serde_json_g1_roundtrip() {
+    let serialized = serde_json::to_string(&G1Affine::generator()).unwrap();
+
+    assert_eq!(
+        serialized,
+        "\"97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb\""
+    );
+
+    let deserialized: G1Affine = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(deserialized, G1Affine::generator());
+}
+
+#[test]
+fn serde_json_g2_roundtrip() {
+    let serialized = serde_json::to_string(&G2Affine::generator()).unwrap();
+
+    assert_eq!(
+        serialized,
+        "\"93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8\""
+    );
+
+    let deserialized: G2Affine = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(deserialized, G2Affine::generator());
+}


### PR DESCRIPTION
We use this library in https://github.com/fedimint/fedimint quite extensively to implement our own threshold cryptography schemes. So far we have manually implemented the serde serialisation for struct that contain bls12_381 scalars or points since we can not derive them. However, we find it increasingly cumbersome and error prone to do so as the implemented schemes get more complex, like amount blinded chaumian ecash or distributed key generation, for example. Therefore we would now like to upstream this improved version of the serialisation we currently use, as we want to built on bls12_381 long term. Please let us know what would be necessary to get this merged as we want to avoid to have to fork.

We serialise using the serdect crate for best efforts constant time serialisation. In the human readable case the types are serialised as hex.