### PR TITLE
Constructors for `Fp`, `G1Affine`, and `G2Affine`

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -11,8 +11,8 @@ use crate::util::{adc, mac, sbb};
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod p, with R = 2^384.
 
-#[allow(missing_docs)]
 #[derive(Copy, Clone)]
+/// Represents an element in the finite field Fp.
 pub struct Fp(pub(crate) [u64; 6]);
 
 impl fmt::Debug for Fp {
@@ -158,11 +158,10 @@ impl<'a, 'b> Mul<&'b Fp> for &'a Fp {
 impl_binops_additive!(Fp, Fp);
 impl_binops_multiplicative!(Fp, Fp);
 
-#[allow(missing_docs)]
 impl Fp {
-    /// Builds an element of `Fp` from a little-endian byte representation.
-    pub fn new_unsafe(bytes: [u64; 6]) -> Self {
-        Fp(bytes)
+    /// Builds an element of `Fp` from little-endian limbs.
+    pub fn new_unsafe(limbs: [u64; 6]) -> Self {
+        Fp(limbs)
     }
 
     /// Returns zero, the additive identity.
@@ -177,6 +176,7 @@ impl Fp {
         R
     }
 
+    /// Checks if this element is zero.
     pub fn is_zero(&self) -> Choice {
         self.ct_eq(&Fp::zero())
     }
@@ -328,6 +328,7 @@ impl Fp {
     }
 
     #[inline]
+    /// Computes the square root of this field element.
     pub fn sqrt(&self) -> CtOption<Self> {
         // We use Shank's method, as p = 3 (mod 4). This means
         // we only need to exponentiate by (p+1)/4. This only
@@ -386,6 +387,7 @@ impl Fp {
     }
 
     #[inline]
+    /// Add two field elements together.
     pub const fn add(&self, rhs: &Fp) -> Fp {
         let (d0, carry) = adc(self.0[0], rhs.0[0], 0);
         let (d1, carry) = adc(self.0[1], rhs.0[1], carry);
@@ -400,6 +402,7 @@ impl Fp {
     }
 
     #[inline]
+    /// Returns the negation of this field element.
     pub const fn neg(&self) -> Fp {
         let (d0, borrow) = sbb(MODULUS[0], self.0[0], 0);
         let (d1, borrow) = sbb(MODULUS[1], self.0[1], borrow);
@@ -425,6 +428,7 @@ impl Fp {
     }
 
     #[inline]
+    /// Squares this element.
     pub const fn sub(&self, rhs: &Fp) -> Fp {
         (&rhs.neg()).add(self)
     }
@@ -569,6 +573,7 @@ impl Fp {
     }
 
     #[inline]
+    /// Multiplies two field elements, returning the result in the Montgomery domain.
     pub const fn mul(&self, rhs: &Fp) -> Fp {
         let (t0, carry) = mac(0, self.0[0], rhs.0[0], 0);
         let (t1, carry) = mac(0, self.0[0], rhs.0[1], carry);

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -1,6 +1,5 @@
 //! This module provides an implementation of the BLS12-381 base field `GF(p)`
 //! where `p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab`
-
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::RngCore;
@@ -11,6 +10,8 @@ use crate::util::{adc, mac, sbb};
 // The internal representation of this type is six 64-bit unsigned
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod p, with R = 2^384.
+
+#[allow(missing_docs)]
 #[derive(Copy, Clone)]
 pub struct Fp(pub(crate) [u64; 6]);
 
@@ -157,7 +158,13 @@ impl<'a, 'b> Mul<&'b Fp> for &'a Fp {
 impl_binops_additive!(Fp, Fp);
 impl_binops_multiplicative!(Fp, Fp);
 
+#[allow(missing_docs)]
 impl Fp {
+    /// Builds an element of `Fp` from a little-endian byte representation.
+    pub fn new_unsafe(bytes: [u64; 6]) -> Self {
+        Fp(bytes)
+    }
+
     /// Returns zero, the additive identity.
     #[inline]
     pub const fn zero() -> Fp {

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -1,5 +1,4 @@
 //! This module implements arithmetic over the quadratic extension field Fp2.
-#![allow(missing_docs)]
 
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
@@ -9,8 +8,11 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use crate::fp::Fp;
 
 #[derive(Copy, Clone)]
+/// Represents an element in the field Fp2.
 pub struct Fp2 {
+    /// The first component of the Fp2 element.
     pub c0: Fp,
+    /// The second component of the Fp2 element.
     pub c1: Fp,
 }
 
@@ -110,6 +112,7 @@ impl_binops_additive!(Fp2, Fp2);
 impl_binops_multiplicative!(Fp2, Fp2);
 
 impl Fp2 {
+    /// Returns the zero element of Fp2.
     #[inline]
     pub const fn zero() -> Fp2 {
         Fp2 {
@@ -118,6 +121,7 @@ impl Fp2 {
         }
     }
 
+    /// Returns the one element of Fp2.
     #[inline]
     pub const fn one() -> Fp2 {
         Fp2 {
@@ -126,10 +130,12 @@ impl Fp2 {
         }
     }
 
+    /// Checks if this element is zero.
     pub fn is_zero(&self) -> Choice {
         self.c0.is_zero() & self.c1.is_zero()
     }
 
+    /// Generates a random element in Fp2.
     pub(crate) fn random(mut rng: impl RngCore) -> Fp2 {
         Fp2 {
             c0: Fp::random(&mut rng),
@@ -145,6 +151,7 @@ impl Fp2 {
         self.conjugate()
     }
 
+    /// Computes the conjugate of this element.
     #[inline(always)]
     pub fn conjugate(&self) -> Self {
         Fp2 {
@@ -153,6 +160,7 @@ impl Fp2 {
         }
     }
 
+    /// Multiplies this element by the non-residue.
     #[inline(always)]
     pub fn mul_by_nonresidue(&self) -> Fp2 {
         // Multiply a + bu by u + 1, getting
@@ -180,6 +188,7 @@ impl Fp2 {
             | (self.c1.is_zero() & self.c0.lexicographically_largest())
     }
 
+    /// Computes the square of this element.
     pub const fn square(&self) -> Fp2 {
         // Complex squaring:
         //
@@ -203,6 +212,7 @@ impl Fp2 {
         }
     }
 
+    /// Multiplies this element by another element.
     pub fn mul(&self, rhs: &Fp2) -> Fp2 {
         // F_{p^2} x F_{p^2} multiplication implemented with operand scanning (schoolbook)
         // computes the result as:
@@ -222,6 +232,7 @@ impl Fp2 {
         }
     }
 
+    /// Adds another element to this element.
     pub const fn add(&self, rhs: &Fp2) -> Fp2 {
         Fp2 {
             c0: (&self.c0).add(&rhs.c0),
@@ -229,6 +240,7 @@ impl Fp2 {
         }
     }
 
+    /// Subtracts another element from this element.
     pub const fn sub(&self, rhs: &Fp2) -> Fp2 {
         Fp2 {
             c0: (&self.c0).sub(&rhs.c0),
@@ -236,6 +248,7 @@ impl Fp2 {
         }
     }
 
+    /// Negates this element.
     pub const fn neg(&self) -> Fp2 {
         Fp2 {
             c0: (&self.c0).neg(),
@@ -243,6 +256,7 @@ impl Fp2 {
         }
     }
 
+    /// Computes the square root of this element.
     pub fn sqrt(&self) -> CtOption<Self> {
         // Algorithm 9, https://eprint.iacr.org/2012/685.pdf
         // with constant time modifications.

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -1,4 +1,5 @@
 //! This module implements arithmetic over the quadratic extension field Fp2.
+#![allow(missing_docs)]
 
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -183,6 +183,11 @@ const B: Fp = Fp::from_raw_unchecked([
 ]);
 
 impl G1Affine {
+    /// Builds a new element of $\mathbb{G}_1$ from raw coordinates.
+    pub fn new_unsafe(x: Fp, y: Fp, infinity: Choice) -> Self {
+        G1Affine { x, y, infinity }
+    }
+
     /// Returns the identity of the group: the point at infinity.
     pub fn identity() -> G1Affine {
         G1Affine {

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -196,6 +196,10 @@ const B: Fp2 = Fp2 {
 const B3: Fp2 = Fp2::add(&Fp2::add(&B, &B), &B);
 
 impl G2Affine {
+    /// Builds a new element of $\mathbb{G}_2$ from raw coordinates.
+    pub fn new_unsafe(x: Fp2, y: Fp2, infinity: Choice) -> Self {
+        G2Affine { x, y, infinity }
+    }
     /// Returns the identity of the group: the point at infinity.
     pub fn identity() -> G2Affine {
         G2Affine {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,9 @@ mod scalar;
 pub use scalar::Scalar;
 
 #[cfg(feature = "groups")]
-mod fp;
+pub mod fp;
 #[cfg(feature = "groups")]
-mod fp2;
+pub mod fp2;
 #[cfg(feature = "groups")]
 mod g1;
 #[cfg(feature = "groups")]


### PR DESCRIPTION
Currently, the way to convert compressed limbs to a `G1Affine` or `G2Affine` type involves calling [`from_uncompressed`], which becomes fairly costly when processing thousands of elliptic curve points. For instance, `from_uncompressed` is the performance bottleneck in [this SP1 profile](https://github.com/0xWOLAND/sp1-revm-kzg-profile/tree/main) (see below). 


## Cycle Counts in SP1

| Operation            | Cycle Count                           |
| -------------------- | ------------------------------------- |
| Uncompress G2 Points | 11,511,799 cycles $\times$ 65 points  |
| Uncompress G1 Points | 1,835,836 cycles $\times$ 4096 points |
| `load_trusted_setup` | 58,994,825  |

In total, `from_compressed` costs 8,737,917,765 cycles even though the trusted setup consists of verified EC points. `load_trusted_setup` [unsafely loads the G1 and G2 points](https://github.com/0xWOLAND/kzg-rs/blob/master/src/parse.rs), which runs significantly faster. 

It would be useful if there was a way to unsafely build the `G1Affine` and `G2Affine` types directly from limbs.