### PR TITLE
bump sha2, sha3, digest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT/Apache-2.0"
 rustdoc-args = ["--html-in-header", "katex-header.html"]
 
 [dependencies]
-digest = { version = "0.10", optional = true }
+digest = { version = "0.10.7", optional = true }
 ff = { version = "0.13", default-features = false }
 group = { version = "0.13", optional = true, default-features = false }
 pairing = { version = "0.23", optional = true }
@@ -30,8 +30,8 @@ csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
 criterion = "0.3"
 hex-literal = "0.3"
 rand_xorshift = "0.3"
-sha2 = "0.10"
-sha3 = "0.10"
+sha2 = "0.10.8"
+sha3 = "0.10.6"
 
 [features]
 default = ["groups", "pairings", "alloc", "bits"]


### PR DESCRIPTION
sha2 0.10.0  is purged so targetting "=0.10.0" fails, thus hash_to_curve is broken as sha2 cant be imported.